### PR TITLE
Add submitter info on view pages

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -28,7 +28,9 @@ class PublicationsController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @submitter = helpers.find_submitter(instance_variable_get("@#{controller_name.singularize}").id) if session[:admin]
+  end
 
   def new
     instance_variable_set("@#{controller_name.singularize}", Object.const_get(controller_name.classify).new)

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -64,6 +64,19 @@
           <th scope="row">DOI:</th>
           <td><%= @book.doi %></td>
         </tr>
+
+        <% if session[:admin] %>
+        
+          <tr>
+            <th scope="row">Submitter ID:</th>
+            <td><%= link_to link_to @submitter.id.to_s, publications_id(@submitter.id) %></td>
+          </tr>
+          <tr>
+            <th scope="row">Submitter Name:</th>
+            <td><%= submitter_name(@submitter) %></td>
+          </tr>
+
+        <% end %>
       </tbody>
       </table>
     </div>

--- a/app/views/other_publications/show.html.erb
+++ b/app/views/other_publications/show.html.erb
@@ -79,6 +79,19 @@
           <th scope="row">DOI:</th>
           <td><%= @other_publication.doi %></td>
         </tr>
+
+        <% if session[:admin] %>
+        
+          <tr>
+            <th scope="row">Submitter ID:</th>
+            <td><%= link_to link_to @submitter.id.to_s, publications_id(@submitter.id) %></td>
+          </tr>
+          <tr>
+            <th scope="row">Submitter Name:</th>
+            <td><%= submitter_name(@submitter) %></td>
+          </tr>
+
+        <% end %>
       </tbody>
       </table>
     </div>

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe BooksController, type: :controller do
     end
   end
 
+  describe 'GET #show as admin' do
+    it 'returns a success response' do
+      FactoryBot.create(:submitter)
+      session[:admin] = true
+      book = Book.create! valid_attributes
+      get :show, params: { id: book.to_param }, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
   describe 'GET #new' do
     it 'returns a success response' do
       get :new, params: {}, session: valid_session

--- a/spec/controllers/other_publications_controller_spec.rb
+++ b/spec/controllers/other_publications_controller_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe OtherPublicationsController, type: :controller do
     end
   end
 
+  describe 'GET #show as admin' do
+    it 'returns a success response' do
+      FactoryBot.create(:submitter)
+      session[:admin] = true
+      other_publication = OtherPublication.create! valid_attributes
+      get :show, params: { id: other_publication.to_param }, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
   describe 'GET #new' do
     it 'returns a success response' do
       get :new, params: {}, session: valid_session


### PR DESCRIPTION
Fixes #59 

Adds information to the view pages so that admins can see the submitters name and their id (which is a link to the publications page)