### PR TITLE
Change email subject and receivers

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,4 +3,4 @@ ADMIN_USERNAME=test
 ADMIN_PASSWORD=password
 
 # Mail Variables
-MAIL_SENDER=norrisms@ucmail.uc.edu
+MAIL_SENDER=sender@invalid.com

--- a/app/mailers/publication_mailer.rb
+++ b/app/mailers/publication_mailer.rb
@@ -7,6 +7,7 @@ class PublicationMailer < ApplicationMailer
   def publication_submit(submitter, publication)
     @submitter = submitter
     @publication = publication
-    mail(to: submitter.email_address, subject: 'AAEC - Publication received')
+    receivers = "#{submitter.email_address}, #{ENV['MAIL_SENDER']}"
+    mail(to: receivers, subject: 'Publication received for Artists, Authors, Editors & Composers')
   end
 end

--- a/spec/mailers/publication_mailer_spec.rb
+++ b/spec/mailers/publication_mailer_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe PublicationMailer, type: :mailer do
     it 'sends an email for a book' do
       book = FactoryBot.create(:book)
       mail = described_class.publication_submit(submitter, book).deliver_now
-      expect(mail.subject).to eq('AAEC - Publication received')
-      expect(mail.to).to eq([submitter.email_address])
+      expect(mail.subject).to eq('Publication received for Artists, Authors, Editors & Composers')
+      expect(mail.to).to eq([submitter.email_address, ENV['MAIL_SENDER']])
       expect(mail.from).to eq([ENV['MAIL_SENDER']])
       expect(mail.body.encoded).to match(book.work_title)
       expect(mail.body.encoded).to match('Please include an address where I may return your publication')


### PR DESCRIPTION
Fixes #71 

Changes the email subject

Sends the email to both the submitter and the sender

Sender email will be set in the .env.production.local