### PR TITLE
Add script to start application if not already running

### DIFF
--- a/script/start-aaec.sh
+++ b/script/start-aaec.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Starts the application if it's not already running
+#
+# Example usage: script/start-aaec.sh /opt/webapps/aaec /aaec production
+
+APP_DIR=$1 # Directory where the app is installed
+WEB_URI=$2 # The sub-URI on the web server where the app can be accessed
+MODE=$3    # production or development
+
+if ! ( [ -f $APP_DIR/tmp/puma/pid ] && pgrep -F $APP_DIR/tmp/puma/pid > /dev/null )
+then
+  cd $APP_DIR
+  export PATH=$APP_DIR/vendor/bundle/ruby/2.6.0/bin:/usr/local/bin:$PATH
+  export RAILS_ENV=$MODE
+  export RAILS_RELATIVE_URL_ROOT=$WEB_URI
+  bin/bundle exec puma -d
+fi


### PR DESCRIPTION
This script can be called when the server starts to get the app running.  Can also be run manually if needed.

I've tested this in my local environment in development mode and on the production server.