### PR TITLE
Replace footer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,44 +12,96 @@
  */
 
 /* Custom bootstrap variables must be set or imported *before* bootstrap. */
- @import "bootstrap";
+@import "bootstrap";
 
- .required:after {
-   content:" *";
+.required:after {
+   content: " *";
    color: red;
- }
-
- .navbar    {
-    background-color: #e00122;
-    color: #fff;
- }
-
- .nav-sub-bar  {
-    background-color: #b8011c;
-    font-size: 1.2rem;
-    font-weight: 700;
-    padding-top: 5px;
-    padding-bottom: 5px;
 }
 
- .offset-footer {
-     margin-bottom: 100px;
- }
+.navbar {
+   background-color: #e00122;
+   color: #fff;
+}
 
- .pagination    {
-    margin-bottom: 0;
- }
+.nav-sub-bar {
+   background-color: #b8011c;
+   font-size: 1.2rem;
+   font-weight: 700;
+   padding-top: 5px;
+   padding-bottom: 5px;
+}
 
- .svg   {
-    fill: #fff;
- }
+.offset-footer {
+   margin-bottom: 40px;
+}
 
- .icon-black   {
-    font-size: 1.5em;
-    color: black;
- }
+.pagination {
+   margin-bottom: 0;
+}
 
- .icon-red   {
+.svg {
+   fill: #fff;
+}
+
+.icon-black {
+   font-size: 1.5em;
+   color: black;
+}
+
+.icon-red {
    font-size: 1.5em;
    color: red;
+}
+
+.footer-top {
+   background-color: #e00122;
+   color: #fff;
+   font-size: 18px;
+}
+
+.footer-top a,
+.footer-top a:hover,
+.footer-top a:active,
+.footer-top a:visited {
+   color: white;
+}
+
+.contact {
+   background-color: #000;
+}
+
+.footer-title {
+   font-size: 1.25rem;
+   margin: 0;
+}
+
+.footer-padding {
+   padding: 40px 40px 0 40px;
+}
+
+.footer-bottom {
+   margin: 20px;
+   font-size: .95rem;
+}
+
+.footer-bottom p {
+   margin: .25rem;
+}
+
+.footer-bottom a:link {
+   color: #000;
+   text-decoration: underline;
+}
+
+.footer-bottom a,
+.footer-bottom a:hover,
+.footer-bottom a:active,
+.footer-bottom a:visited {
+   color: #000;
+   text-decoration: none;
+}
+
+.thin-text {
+   font-weight: 100;
 }

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,117 @@
+<div class="container-fluid footer-top">
+    <div class="container">
+        <div class="row">
+            <div class="col contact footer-padding">
+                <p class="social-icons d-flex justify-content-around">
+
+                    <a href="https://www.facebook.com/uclibraries/" target="_blank" aria-label="Facebook"><i
+                            class="fab fa-facebook fa-2x" aria-hidden="true"></i></a>
+
+
+                    <a href="http://twitter.com/uclibraries" target="_blank" aria-label="Twitter"><i
+                            class="fab fa-twitter fa-2x" aria-hidden="true"></i></a>
+
+
+                    <a href="https://www.instagram.com/uc_libraries" target="_blank" aria-label="Instagram"><i
+                            class="fab fa-instagram fa-2x" aria-hidden="true"></i></a>
+
+
+                    <a href="https://www.youtube.com/user/STRC1" target="_blank" aria-label="Youtube"><i
+                            class="fab fa-youtube fa-2x" aria-hidden="true"></i></a>
+                </p>
+                <p>
+                    University of Cincinnati Libraries
+                    <br>PO Box 210033
+                    <br>Cincinnati, Ohio
+                    <br>45221-0033
+                    <br> <a href="https://libraries.uc.edu/about/contact.html">Contact Us</a> | <a
+                        href="https://libapps.libraries.uc.edu/main/contact/staff_directory.php">Staff
+                        Directory</a>
+                </p>
+
+            </div>
+            <div class="col footer-padding">
+                <p class="footer-title"><strong>UC Tools</strong></p>
+                <ul class="list-unstyled">
+                    <div class="row">
+                        <div class="col thin-text">
+                            <li><a href="https://canopy.uc.edu">Canopy &amp; Blackboard</a></li>
+
+
+                            <li><a href="https://onestop.uc.edu">One Stop</a></li>
+
+
+                            <li><a href="https://mail.uc.edu">Email</a></li>
+
+
+                            <li><a href="https://catalyst.uc.edu/">Catalyst</a></li>
+
+
+                            <li><a href="http://uc.doublemap.com/map/">Shuttle Tracker</a></li>
+
+
+                            <li><a href="https://www.ucflex.uc.edu/">UC Flex/ESS</a></li>
+                        </div>
+                        <div class="col thin-text">
+                            <li><a href="https://www.uc.edu/about/ucit/help.html">IT Help</a></li>
+
+
+                            <li><a href="https://vpn.uc.edu">UC VPN</a></li>
+
+
+                            <li><a href="https://www.uc.edu/af/travel/concur-travel.html">Concur</a></li>
+
+
+                            <li><a href="https://www.uc.edu/hr/tools/successfactors.html">Success Factors</a></li>
+
+
+                            <li><a href="https://mailuc.sharepoint.com/sites/Intranet">Bearcats Landing</a></li>
+                        </div>
+                    </div>
+
+                </ul>
+
+            </div>
+            <div class="col footer-padding">
+                <p class="footer-title"><strong>About Us</strong></p>
+                <ul class="list-unstyled thin-text">
+                    <li><a href="https://www.uc.edu/visitors.html">Maps &amp; Directions</a></li>
+
+                    <li><a href="https://jobs.uc.edu/">Jobs</a></li>
+
+                    <li><a href="https://uc.edu/news">News</a></li>
+
+                    <li><a href="https://www.uc.edu/inclusion.html">Diversity</a></li>
+
+                    <li><a href="http://www.uc.edu/about/policies.html">Governance &amp; Policies</a></li>
+
+                    <li><a href="https://www.uc.edu/employees.html">Employees</a></li>
+
+                    <li><a href="https://ucdirectory.uc.edu">Directory</a></li>
+
+                    <li><a href="https://uc.edu/calendar">Events Calendar</a></li>
+                </ul>
+
+            </div>
+        </div>
+    </div>
+</div>
+<div class="footer-bottom">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <p><strong>University of Cincinnati</strong> | 2600 Clifton Ave. | Cincinnati, OH 45221 | ph:
+                    513-556-6000</p>
+                <p><a href="https://www.uc.edu/alert.html">Alerts</a> | <a
+                        href="https://www.uc.edu/about/publicsafety/clery/annual-security-report.html">Clery and
+                        HEOA Notice</a> | <a href="https://www.uc.edu/about/non-discrimination">Notice of
+                        Non-Discrimination</a> | <a
+                        href="https://www.uc.edu/about/ucit/about/accessibility/eaccessibility-form.html">eAccessibility
+                        Concern</a> | <a href="https://www.uc.edu/about/privacy">Privacy Statement</a> | <a
+                        href="http://commercialization.uc.edu/copyright-infringement">Copyright Information</a>
+                </p>
+                <p>&copy; 2019 University of Cincinnati</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,18 +60,6 @@
       </div>
     </div>
     <%= yield %>
-
-    <footer class="footer fixed-bottom" style="background-color: #000 !important;">
-      <div class="pt-2 container d-flex justify-content-center">
-      <span class="text-white">Developed by the <%= link_to "University of Cincinnati Libraries", "https://libraries.uc.edu/", target: "_blank", class: "text-white" %>: <%= link_to "Application Development Unit", "https://github.com/uclibs", target: "_blank", class: "text-white" %></span>
-      </div>
-      <div class="py-1 container d-flex justify-content-center">
-        <a class="text-white px-2" href="https://www.uc.edu/alert.html">Alerts </a> 
-        <a class="text-white px-2" href="https://www.uc.edu/publicsafety/annual-security-report.html">Clery and HEOA Notice </a> 
-        <a class="text-white px-2" href="https://uc.edu/about/policies/non-discrimination.html">Notice of Non-Discrimination </a>
-        <a class="text-white px-2" href="https://www.uc.edu/ucit/community/accessibility/eAccessibility-form.html">eAccessibility Concern </a> 
-        <a class="text-white px-2" href="https://www.ipo.uc.edu/index.cfm?fuseaction=home.infringement">Copyright Information </a>
-      </div>
-    </footer>
+    <%= render partial: 'layouts/footer' %>
   </body>
 </html>

--- a/spec/features/create_film_spec.rb
+++ b/spec/features/create_film_spec.rb
@@ -38,7 +38,6 @@ describe 'Create a film', :feature, js: true do
     expect(page).to have_text 'Department'
     expect(page).to have_text 'Title'
     expect(page).not_to have_text 'Subtitle'
-    expect(page).not_to have_text 'Director'
     expect(page).not_to have_text 'Release year'
   end
 end


### PR DESCRIPTION
Made changes to make the footer very similar to the footer used by UC Libraries. While the footer is not the exact same, it is very close.

Differences:
* Social Media links are spaced slightly differently, and when hovered they stay white instead of red
* I didn't want to import a new font for speed and simplicity's sake, so the text is slightly thicker
* Added slight margin to the bottom footer to be easier to read
* The footer from UC doesn't use the current bootstrap sizing guide, so our footer will handle differently with small  screens. Also makes our height a little shorter

Overall:
It is very similar, and not noticeable unless you directly compare them to each other. All major differences are either a result of better readability/usability, or UC not using a standard bootstrap approach to their footer