### PR TITLE
Deploy to libappstest instead of aramis

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -8,7 +8,7 @@ set :bundle_path, -> { shared_path.join('vendor/bundle') }
 append :linked_dirs, 'tmp', 'log'
 ask(:username, nil)
 ask(:password, nil, echo: false)
-server 'aramis.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22, roles: %i[web app db]
+server 'libappstest.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22, roles: %i[web app db]
 set :deploy_to, '/opt/webapps/aaec'
 after 'deploy:updating', 'init_qp'
 before 'deploy:cleanup', 'start_qp'


### PR DESCRIPTION
Changing the server we use for QA deploys.  aramis is being replaced by libappstest

I've tested this change and the deploy had no problems.
https://libappstest.libraries.uc.edu/aaec