### PR TITLE
Allow capfile to be used with all capistrano 3.x versions

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.11.2'
+lock '~> 3.11'
 
 set :application, 'AAEC'
 set :repo_url, 'https://github.com/uclibs/aaec.git'


### PR DESCRIPTION
The config/deploy.rb file had locked the capistrano version to 3.11.x, but we've upgraded to capistrano 3.14.  I was receiving a `Capfile locked at ~> 3.11.2, but 3.14.1 is loaded` error when trying to deploy.

This tweak will allow our capistrano config to work with any 3.x version.

I've tested this with a deploy to libappstest.