### PR TITLE
add github issue_template & pull_request_template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+### Descriptive summary
+
+Include a concise description of the issue and any relevant tracebacks if you're reporting a bug.
+
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the behavior
+
+1. Do this
+1. Then do this...
+
+### Related work
+
+Link to related issues or prior related work here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+Fixes #issuenumber ; refs #issuenumber
+
+Present short summary (50 characters or less)
+
+More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.
+
+Description can have multiple paragraphs and you can use code examples inside:
+
+``` ruby
+class PostsController
+  def index
+    respond_with Post.limit(10)
+  end
+end
+```
+
+Changes proposed in this pull request:
+* 
+* 
+* 


### PR DESCRIPTION
Fixes #170 
This PR creates a new folder and 2 files.  GitHub has the ability to configure templates, but there is also a new beta feature that will allow us to use .yml files to create forms for issue submission.  This PR has 2 .md files, echoing the set up in our app [ucrate](https://github.com/uclibs/ucrate).  In the future, we may want to switch over to .yml form submission for issues, but putting in the template as .md files instead of a GitHub configuration moves us in that direction while increasing congruence between our apps.

I imported over the ISSUE_TEMPLATE and the PULL_REQUEST_TEMPLATE that are already in use in ucrate.