### PR TITLE
150 resolved dynamic-render-path-vulnerability

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,7 +7,7 @@ class PagesController < ApplicationController
 
   def show
     if valid_page?
-      render template: "pages/#{ALLOWED_PAGES.find { |page| page == params[:page].to_s }}"
+      render template: "pages/#{safe_page}"
     else
       render file: 'public/404.html', status: :not_found
     end
@@ -17,5 +17,9 @@ class PagesController < ApplicationController
 
   def valid_page?
     params[:page].is_a?(String) && ALLOWED_PAGES.include?(params[:page])
+  end
+
+  def safe_page
+    ALLOWED_PAGES.find { |page| page == params[:page].to_s }
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,10 +2,8 @@
 
 # app/controllers/pages_controller.rb
 class PagesController < ApplicationController
-  ALLOWED_PAGES = %w[closed finished].freeze
-
   skip_before_action :check_date
-  VALID_PAGES = %w[closed finished].freeze # Add or remove pages as needed
+  ALLOWED_PAGES = %w[closed finished].freeze
 
   def show
     if valid_page?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+# app/controllers/pages_controller.rb
 class PagesController < ApplicationController
+  ALLOWED_PAGES = %w[closed finished].freeze
+
   skip_before_action :check_date
   VALID_PAGES = %w[closed finished].freeze # Add or remove pages as needed
 
   def show
     if valid_page?
-      render template: "pages/#{params[:page]}"
+      render template: "pages/#{ALLOWED_PAGES.find { |page| page == params[:page].to_s }}"
     else
       render file: 'public/404.html', status: :not_found
     end
@@ -15,6 +18,6 @@ class PagesController < ApplicationController
   private
 
   def valid_page?
-    VALID_PAGES.include?(params[:page])
+    params[:page].is_a?(String) && ALLOWED_PAGES.include?(params[:page])
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -35,4 +35,24 @@ RSpec.describe PagesController, type: :controller do
       expect(PagesController::ALLOWED_PAGES).to match_array(page_files)
     end
   end
+
+  describe '#safe_page' do
+    let(:params) { {} }
+    let(:allowed_pages) { %w[home about contact] }
+
+    before do
+      allow(controller).to receive(:params).and_return(params)
+      stub_const("#{PagesController}::ALLOWED_PAGES", allowed_pages)
+    end
+
+    it 'returns nil if the page is not in ALLOWED_PAGES' do
+      params[:page] = 'unallowed_page'
+      expect(controller.send(:safe_page)).to be_nil
+    end
+
+    it 'returns the page if it is in ALLOWED_PAGES' do
+      params[:page] = 'home'
+      expect(controller.send(:safe_page)).to eq('home')
+    end
+  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -23,18 +23,9 @@ RSpec.describe PagesController, type: :controller do
     end
   end
 
-  # When adding a new page, you need to add it to the VALID_PAGES constant in
+  # When adding a new page, you need to add it to the ALLOWED_PAGES constant in
   # app/controllers/pages_controller.rb. This test ensures that the constant
   # is kept up to date.
-  describe 'VALID_PAGES' do
-    it 'contains all the pages in app/views/pages' do
-      view_pages = Dir[Rails.root.join('app', 'views', 'pages', '*.html.erb')]
-                   .map { |path| File.basename(path, '.html.erb') }
-
-      expect(PagesController::VALID_PAGES).to match_array(view_pages)
-    end
-  end
-
   describe 'ALLOWED_PAGES constant' do
     it 'contains all the valid pages in app/views/pages' do
       page_files = Dir.glob('app/views/pages/*.html.erb').map do |file|

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe PagesController, type: :controller do
       expect(PagesController::VALID_PAGES).to match_array(view_pages)
     end
   end
+
+  describe 'ALLOWED_PAGES constant' do
+    it 'contains all the valid pages in app/views/pages' do
+      page_files = Dir.glob('app/views/pages/*.html.erb').map do |file|
+        File.basename(file, '.html.erb')
+      end
+
+      expect(PagesController::ALLOWED_PAGES).to match_array(page_files)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #150 

Fix Dynamic Render Path Vulnerability in PagesController

This PR addresses a security concern raised by Brakeman concerning dynamic render paths in the PagesController. Specifically, Brakeman flagged the use of params[:page] directly in a render call as a potential risk.

Changes:
Refactored PagesController to use a whitelist approach for page rendering.
Added a type check to ensure that params[:page] is a string.
Added test for the whitelist to ensure that future developers do not add a page without adding it to the whitelist.


