### PR TITLE
changed spec_helper to have random seed for tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,7 +108,7 @@ RSpec.configure do |config|
   #   # order dependency and want to debug it, you can fix the order by providing
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
-  #   # config.order = :random
+  config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
We recently discovered that the tests for aaec weren't being run in a random order.  This pr changes the config file so that the rspec tests will be run using a different seed each time.