### PR TITLE
146: added bundler-audit, bumped puma from 3.12.4 to 6.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '~> 6.1.7.6'
 # gem 'sqlite3'
 
 # Use Puma as the app server
-gem 'puma', '~> 3.12.4'
+gem 'puma', '>= 6.3.1'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
@@ -54,6 +54,7 @@ gem 'truncato'
 gem 'webpacker'
 
 group :development, :test do
+  gem 'bundler-audit', '~> 0.9.1'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
       sassc-rails (>= 2.0.0)
     brakeman (6.0.1)
     builder (3.2.4)
+    bundler-audit (0.9.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     byebug (11.1.3)
     capistrano (3.17.3)
       airbrussh (>= 1.0.0)
@@ -187,10 +190,6 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
-      racc (~> 1.4)
     pagy (3.11.0)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -198,7 +197,8 @@ GEM
       racc
     popper_js (1.16.1)
     public_suffix (5.0.3)
-    puma (3.12.6)
+    puma (6.3.1)
+      nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
     rack-proxy (0.7.7)
@@ -322,8 +322,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.4-arm64-darwin)
-    sqlite3 (1.6.4-x86_64-darwin)
-    sqlite3 (1.6.4-x86_64-linux)
     sshkit (1.21.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -366,14 +364,13 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
   bcrypt_pbkdf
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.4.1)
   brakeman (~> 6.0)
+  bundler-audit (~> 0.9.1)
   byebug
   capistrano (~> 3.17.1)
   capistrano-bundler (~> 1.6)
@@ -394,7 +391,7 @@ DEPENDENCIES
   mysql2
   net-smtp
   pagy (~> 3.7)
-  puma (~> 3.12.4)
+  puma (>= 6.3.1)
   rails (~> 6.1.7.6)
   rails-controller-testing
   rb-readline


### PR DESCRIPTION
Fixes #146 

Added the gem "bundler-audit" to gemfile and ran bundle install and bundle update.  Then ran bundler-audit.  The only security issues bundler-audit identified were related to puma, which we had pinned to version 3.12.4.  Bundler and Dependabot both suggest upgrading puma to either >= 5.7.1 or >= 6.3.1.  I chose 6.3.1 because as a newer version it's more likely to have a longer shelf life than the 5.7.1 version.  

No conflicts were encountered, and our internal testing still runs without error.  Due to the fact that this is a major update with puma, I'm thinking we may want to test-deploy this branch to make sure that puma still plays nice with our codebase and configurations before we merge it up.
