### PR TITLE
Create new dependabot.yml file for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # "bundler" includes "rubygems"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # "npm" includes "yarn" and "pnpm"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Fixes #188

We have been having issues where pull requests were not created with Dependabot, and security updates were not getting noticed.  This PR creates a new .github/dependabot.yml file that configures Dependabot to run weekly scans for all dependencies and automatically create pull requests for them.

Included in the file:
update ruby gems via the "bundler" ecosystem
update yarn.lock via the "npm" ecosystem
update docker via the "docker" ecosystem*

*note - there is some discussion about whether we are going to continue to have docker files or not, but as of the time of this writing the docker files are still present so should be updated.  Reference to them can be removed when we remove docker files, but nothing should break if we try to update them and they're not there.

