### PR TITLE
202: updated pagy to 6.0.4, updated config/initializers/pagy file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'dotenv-rails'
 gem 'ed25519'
 gem 'jquery-rails'
 gem 'net-smtp'
-gem 'pagy', '~> 3.7'
+gem 'pagy', '~> 6.0.4'
 gem 'truncato'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       railties (>= 3.2)
     ed25519 (1.3.0)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -192,11 +192,7 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
-      racc (~> 1.4)
-    pagy (3.11.0)
+    pagy (6.0.4)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -268,7 +264,7 @@ GEM
     rspec-support (3.12.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.56.2)
+    rubocop (1.56.3)
       base64 (~> 0.1.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -315,9 +311,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.4-arm64-darwin)
-    sqlite3 (1.6.4-x86_64-darwin)
-    sqlite3 (1.6.4-x86_64-linux)
+    sqlite3 (1.6.6-arm64-darwin)
     sshkit (1.21.5)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -325,7 +319,7 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.2.2)
-    tilt (2.2.0)
+    tilt (2.3.0)
     timeout (0.4.0)
     tins (1.32.1)
       sync
@@ -345,7 +339,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -355,8 +349,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
-  x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
   bcrypt_pbkdf
@@ -384,7 +376,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.9)
   mysql2
   net-smtp
-  pagy (~> 3.7)
+  pagy (~> 6.0.4)
   puma (>= 6.3.1)
   rails (~> 6.1.7.6)
   rails-controller-testing

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -103,7 +103,7 @@ require 'pagy/extras/bootstrap'
 
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
-Pagy::VARS[:items] = 10 # default
+Pagy::DEFAULT[:items] = 10 # default
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  include ApplicationHelper
+
+  controller do
+    def index
+      render plain: 'Hello, world!'
+    end
+  end
+
+  describe 'before_action :check_date' do
+    context 'when EXPIRATION_DATE is in the past and user is not admin' do
+      it 'redirects to the closed page' do
+        allow(ENV).to receive(:fetch).with('EXPIRATION_DATE').and_return('2000-01-01')
+        get :index
+        expect(response).to redirect_to(page_route('closed'))
+      end
+    end
+
+    context 'when EXPIRATION_DATE is in the future' do
+      it 'does not redirect' do
+        allow(ENV).to receive(:fetch).with('EXPIRATION_DATE').and_return('3000-01-01')
+        get :index
+        expect(response.body).to eq('Hello, world!')
+      end
+    end
+
+    context 'when user is admin' do
+      it 'does not redirect' do
+        session[:admin] = true
+        allow(ENV).to receive(:fetch).with('EXPIRATION_DATE').and_return('2000-01-01')
+        get :index
+        expect(response.body).to eq('Hello, world!')
+      end
+    end
+
+    context 'when EXPIRATION_DATE is missing' do
+      it 'raises a KeyError' do
+        allow(ENV).to receive(:fetch).with('EXPIRATION_DATE').and_raise(KeyError)
+        expect { get :index }.to raise_error(KeyError)
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# spec/helpers/application_helper_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#signed_in' do
+    it 'returns true if admin is signed in' do
+      session[:admin] = true
+      expect(signed_in).to eq(true)
+    end
+
+    it 'returns submitter_id if submitter is signed in' do
+      session[:submitter_id] = 5
+      expect(signed_in).to eq(5)
+    end
+
+    it 'returns nil if no one is signed in' do
+      expect(signed_in).to be_nil
+    end
+  end
+
+  describe '#shorten_long' do
+    it 'shortens a long string' do
+      expect(shorten_long('thisisaverylongstringwithmorecharacters')).to eq('thisisaverylongs... ')
+    end
+
+    it 'does not shorten a short string' do
+      expect(shorten_long('short')).to eq('short ')
+    end
+
+    it 'returns an empty string if an empty string is provided' do
+      expect(shorten_long('')).to eq('')
+    end
+  end
+
+  describe '#csv_route' do
+    it 'returns the correct csv route' do
+      allow(ENV).to receive(:[]).with('RAILS_RELATIVE_URL_ROOT').and_return('/root')
+      expect(csv_route('test')).to eq('/root/csv/test.csv')
+    end
+
+    it 'returns the correct csv route when ENV is not set' do
+      allow(ENV).to receive(:[]).with('RAILS_RELATIVE_URL_ROOT').and_return(nil)
+      expect(csv_route('test')).to eq('/csv/test.csv')
+    end
+  end
+
+  describe '#page_route' do
+    it 'returns the correct page route' do
+      allow(ENV).to receive(:[]).with('RAILS_RELATIVE_URL_ROOT').and_return('/root')
+      expect(page_route('test')).to eq('/root/pages/test')
+    end
+
+    it 'returns the correct page route when ENV is not set' do
+      allow(ENV).to receive(:[]).with('RAILS_RELATIVE_URL_ROOT').and_return(nil)
+      expect(page_route('test')).to eq('/pages/test')
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# spec/helpers/application_helper_spec.rb
-
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do


### PR DESCRIPTION
Fixes #202 

Reference: [the pagy change logs for version 5.0.0](https://github.com/ddnexus/pagy/blob/master/CHANGELOG_LEGACY.md#version-500)

There was a breaking change for us in moving from pagy version 3.11.0 to version 6.0.4.  Upon migrating from 4.11.0 to 5.0.0, support had been removed for the deprecated variable Pagy::VARS.  Instead, it had been renamed to Pagy::DEFAULT.  We had used Pagy::VARS in our config/initializers/pagy.rb file, so when we were attempting to migrate to 6.0.4, we were unable to successfully initialize anything that used pagy.

This PR:

- Replaces Pagy::VARS with Pagy::DEFAULT in the pagy.rb file
- Updates pagy in the gemfile to ~> 6.0.4.
- Runs "bundle update" after updating pagy.
- Adds tests for controllers/application_controller.rb (the only time we call Pagy::Backend)
- Adds tests for helpers/application_helper.rb (the only time we call Pagy::Frontend)
