### PR TITLE
160 start aaec sh to use rbenv

### DIFF
--- a/scripts/start_local.sh
+++ b/scripts/start_local.sh
@@ -1,11 +1,87 @@
 #!/bin/bash
+
+# Check for .env.development.local file
 if [ ! -f "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/static/.env.development.local" ]; then
-    echo "Missing updated .env.development.local file in the static directory. The server may not function properly"
+    echo "Missing updated .env.development.local file in the static directory. The server may not function properly."
 else
     cp "$(dirname "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )" )/static/.env.development.local" "$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" )"
 fi
 
-# Kill rails server if exists
-kill -9 $(lsof -i tcp:3000 -t) 2> /dev/null
-export RBENV_VERSION=3.2.2
-bundle exec rails server -p 3000 -b 0.0.0.0 -d
+# Safely kill Rails server if exists
+pids=$(lsof -i tcp:3000 -t)
+if [ -n "$pids" ]; then
+  kill -15 $pids
+  sleep 2  # Wait for processes to terminate
+
+  # If processes are still running, use kill -9
+  if lsof -i tcp:3000 -t > /dev/null; then
+    kill -9 $pids
+  fi
+fi
+
+# Function to check if Ruby 3.2.2 is installed
+check_ruby_version() {
+  if rbenv versions --bare | grep -q '3.2.2'; then
+    return 0
+  elif rvm list strings | grep -q 'ruby-3.2.2'; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Function to start Rails server with rbenv
+start_with_rbenv() {
+  export RBENV_VERSION=3.2.2
+  bundle exec rails server -p 3000 -b 0.0.0.0 -d
+  return $?
+}
+
+# Function to start Rails server with RVM
+start_with_rvm() {
+  source "$HOME/.rvm/scripts/rvm"
+  bundle exec rails server -p 3000 -b 0.0.0.0 -d
+  return $?
+}
+
+# Check if Ruby 3.2.2 is installed
+if check_ruby_version; then
+  echo "Ruby 3.2.2 is installed."
+else
+  echo "Ruby 3.2.2 is not installed. Do you want to install it? (y/n)"
+  read answer
+  if [ "$answer" == "y" ]; then
+    if command -v rbenv > /dev/null; then
+      rbenv install 3.2.2
+    elif command -v rvm > /dev/null; then
+      rvm install 3.2.2
+    else
+      echo "Neither rbenv nor RVM is installed. Exiting."
+      exit 1
+    fi
+  else
+    echo "Exiting."
+    exit 1
+  fi
+fi
+
+# Attempt to start with rbenv
+start_with_rbenv
+
+# Check if the start was successful
+if [ $? -eq 0 ]; then
+  echo "Successfully started with rbenv."
+else
+  echo "Failed to start with rbenv. Trying with RVM..."
+  
+  # Attempt to start with RVM
+  start_with_rvm
+  
+  # Check if the start was successful
+  if [ $? -eq 0 ]; then
+    echo "Successfully started with RVM."
+  else
+    echo "Failed to start with both rbenv and RVM."
+    exit 1
+  fi
+fi

--- a/scripts/start_local.sh
+++ b/scripts/start_local.sh
@@ -7,4 +7,5 @@ fi
 
 # Kill rails server if exists
 kill -9 $(lsof -i tcp:3000 -t) 2> /dev/null
-source "$HOME/.rvm/scripts/rvm" && bundle exec rails server -p 3000 -b 0.0.0.0 -d
+export RBENV_VERSION=3.2.2
+bundle exec rails server -p 3000 -b 0.0.0.0 -d


### PR DESCRIPTION
Fixes #160 
scripts/start_aaec.sh needs to use rbenv instead of rvm.

Scripts/start_aaec.sh doesn't actually call for the use of either rbenv or rvm.  Here's the old version of the file:
```
#!/bin/bash
#
# Starts the application if it's not already running
#
# Example usage: script/start-aaec.sh /opt/webapps/aaec /aaec production

APP_DIR=$1 # Directory where the app is installed
WEB_URI=$2 # The sub-URI on the web server where the app can be accessed
MODE=$3    # production or development

if ! ( [ -f $APP_DIR/tmp/puma/pid ] && pgrep -F $APP_DIR/tmp/puma/pid > /dev/null )
then
  cd $APP_DIR
  export PATH=$APP_DIR/vendor/bundle/ruby/3.2.2/bin:/usr/local/bin:$PATH
  export RAILS_ENV=$MODE
  export RAILS_RELATIVE_URL_ROOT=$WEB_URI
  bin/bundle exec puma -d
fi
```
Here's what ChatGPT had to say about the script:
Certainly, let's walk through the Bash script line by line to understand what it's doing:

1. `#!/bin/bash`: This is the shebang line, telling the system that the script should be executed with the `bash` shell.

2. `# Starts the application if it's not already running`: A comment line to describe what the script does.

3. `# Example usage: script/start-aaec.sh /opt/webapps/aaec /aaec production`: Another comment providing an example of how to run the script.

4. `APP_DIR=$1`: Sets the variable `APP_DIR` to the value of the first argument passed to the script. This is the directory where the app is installed.

5. `WEB_URI=$2`: Sets `WEB_URI` to the second argument, which is the sub-URI where the app can be accessed.

6. `MODE=$3`: Sets `MODE` to the third argument, which specifies whether the app is running in "production" or "development" mode.

7. `if ! ( [ -f $APP_DIR/tmp/puma/pid ] && pgrep -F $APP_DIR/tmp/puma/pid > /dev/null )`: This is an `if` condition that checks if the Puma server (commonly used with Rails) is not running. It does so by checking if a PID file exists and if a process with that PID is running.

8. `then`: Starts the block of code to execute if the `if` condition is true.

9. `cd $APP_DIR`: Changes the current directory to the app directory specified by `APP_DIR`.

10. `export PATH=$APP_DIR/vendor/bundle/ruby/3.2.2/bin:/usr/local/bin:$PATH`: Sets the `PATH` environment variable to include the Ruby 3.2.2 bundled executables directory and other directories.

11. `export RAILS_ENV=$MODE`: Sets the Rails environment (`RAILS_ENV`) to the `MODE` specified (either "production" or "development").

12. `export RAILS_RELATIVE_URL_ROOT=$WEB_URI`: Sets the relative URL root for the Rails app.

13. `bin/bundle exec puma -d`: Runs Puma in daemon mode (`-d`) using the bundled Ruby.

14. `fi`: Ends the `if` block.

This script doesn't specifically use RVM or rbenv. The Ruby version and dependencies are set using the `PATH` environment variable, which is set to look at the Ruby executable in the `vendor/bundle/ruby/3.2.2/bin` directory.

...

The line export PATH=$APP_DIR/vendor/bundle/ruby/3.2.2/bin:/usr/local/bin:$PATH is more indicative of a "bundled" Ruby setup, potentially used in deployment environments to isolate dependencies. This is often seen in environments where you bundle Ruby and its gems together with your application code, such as in certain Docker or Capistrano setups.

In summary, the setting of the PATH in the script doesn't align well with how rbenv or RVM usually manage Ruby versions, and it's more indicative of a setup where the Ruby version and gems are bundled directly with the application.

**SO!!!**

I have not modified the scripts/start-aaec.sh file.  I DID notice, however, that the scripts/start-local.sh file was expecting the user to be using rvm.  Since it's possible that our developers might be using RVM and it shouldn't really matter for the sake of development, I updated the start-local.sh script to try to start the app with either rbenv or rvm versions, and to attempt to install a missing Ruby version 3.2.2 if asked.


