### PR TITLE
131 added tests for channels, jobs, and publications_helper

### DIFF
--- a/app/helpers/publications_helper.rb
+++ b/app/helpers/publications_helper.rb
@@ -72,10 +72,10 @@ module PublicationsHelper
     return_string = "#{author_citation(publication)}. "
 
     # Prefer the city over the location
-    location_or_city = preprocess_attr(publication, :city, :location)
+    city_or_location = preprocess_attr(publication, :city, :location)
 
     # Prefer the publication date over the date
-    date_or_publication_date = preprocess_attr(publication, :publication_date, :date)
+    publication_date_or_date = preprocess_attr(publication, :publication_date, :date)
 
     # Prefer the DOI over the URL
     doi_or_url = preprocess_attr(publication, :doi, :url)
@@ -83,11 +83,11 @@ module PublicationsHelper
     attributes_to_check = [
       { attr: preprocess_attr(publication, :other_title), format: '“%s”. ' },
       { attr: preprocess_attr(publication, :work_title), format: '<i>%s</i>' },
-      { attr: location_or_city, format: ', %s' },
+      { attr: city_or_location, format: ', %s' },
       { attr: preprocess_attr(publication, :publisher), format: ', %s' },
       { attr: preprocess_attr(publication, :volume), format: ', vol. %s' },
       { attr: preprocess_attr(publication, :issue), format: ', no. %s' },
-      { attr: date_or_publication_date, format: ', %s' },
+      { attr: publication_date_or_date, format: ', %s' },
       { attr: preprocess_attr(publication, :page_numbers), format: ', pp. %s' },
       { attr: doi_or_url, format: '. %s' }
     ].compact

--- a/app/helpers/publications_helper.rb
+++ b/app/helpers/publications_helper.rb
@@ -16,6 +16,8 @@ module PublicationsHelper
   end
 
   def author_citation(publication)
+    return '' if publication.blank? || publication.author_first_name.nil? || publication.author_last_name.nil?
+
     author_list = ''
     size = [0, (publication.author_first_name.count - 1)].max
     if size.zero?
@@ -38,6 +40,8 @@ module PublicationsHelper
   end
 
   def authors_array(publication)
+    return [] if publication.blank? || publication.author_first_name.nil? || publication.author_last_name.nil?
+
     author_array = []
     size = [0, (publication.author_first_name.count - 1)].max
     (0..size).each do |i|
@@ -65,33 +69,52 @@ module PublicationsHelper
   def create_citation(publication)
     return if publication.nil?
 
-    return_string = ''
-    return_string += "#{author_citation(publication)}. "
-    return_string += "“#{publication.other_title}”. " unless publication.other_title.blank?
-    return_string += "'<i>'#{publication.work_title}"
-    return_string += '</i>'
-    @loc_city = publication.location if publication.respond_to? :location
-    @loc_city = publication.city if publication.respond_to? :city
-    return_string += ", #{@loc_city}" if @loc_city != ''
-    return_string += ", #{publication.publisher}" if (publication.publisher != '' if publication.respond_to? :publisher)
-    return_string += ", vol. #{publication.volume}" if (publication.volume != '' if publication.respond_to? :volume)
-    return_string += ", no. #{publication.issue}" if (publication.issue != '' if publication.respond_to? :issue)
-    @date = publication.date if publication.respond_to? :date
-    @date = publication.publication_date if publication.respond_to? :publication_date
-    return_string += ", #{@date.last(4)}" if @date != ''
-    return_string += ", pp. #{publication.page_numbers}" if (publication.page_numbers != '' if publication.respond_to? :page_numbers)
-    if (publication.doi != '' if publication.respond_to? :doi)
-      return_string += ". #{publication.doi}"
-    elsif (publication.url != '' if publication.respond_to? :url)
-      return_string += ". #{publication.url}"
+    return_string = "#{author_citation(publication)}. "
+
+    # Prefer the city over the location
+    location_or_city = preprocess_attr(publication, :city, :location)
+
+    # Prefer the publication date over the date
+    date_or_publication_date = preprocess_attr(publication, :publication_date, :date)
+
+    # Prefer the DOI over the URL
+    doi_or_url = preprocess_attr(publication, :doi, :url)
+
+    attributes_to_check = [
+      { attr: preprocess_attr(publication, :other_title), format: '“%s”. ' },
+      { attr: preprocess_attr(publication, :work_title), format: '<i>%s</i>' },
+      { attr: location_or_city, format: ', %s' },
+      { attr: preprocess_attr(publication, :publisher), format: ', %s' },
+      { attr: preprocess_attr(publication, :volume), format: ', vol. %s' },
+      { attr: preprocess_attr(publication, :issue), format: ', no. %s' },
+      { attr: date_or_publication_date, format: ', %s' },
+      { attr: preprocess_attr(publication, :page_numbers), format: ', pp. %s' },
+      { attr: doi_or_url, format: '. %s' }
+    ].compact
+
+    attributes_to_check.each do |item|
+      return_string << (item[:format] % item[:attr]) if item[:attr]
     end
-    @loc_city = ''
-    @date = ''
-    return_string += '.'
+
+    return_string.chomp!(', ')
+    return_string << '.'
+
     return_string
   end
 
   def author_or_artist_label
     params['controller'] == 'artworks' ? 'Artist' : 'Author'
+  end
+
+  private
+
+  def preprocess_attr(publication, *attrs)
+    attrs.each do |attr|
+      if publication.respond_to?(attr) && publication.send(attr).present?
+        value = publication.send(attr)
+        return value.is_a?(String) ? value.strip : nil
+      end
+    end
+    nil
   end
 end

--- a/spec/channels/application_cable/channel_spec.rb
+++ b/spec/channels/application_cable/channel_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# spec/channels/application_cable/channel_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Channel, type: :channel do
+  it 'inherits from ActionCable::Channel::Base' do
+    expect(described_class).to be < ActionCable::Channel::Base
+  end
+end

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# spec/cable/application_cable/connection_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  it 'inherits from ActionCable::Connection::Base' do
+    expect(described_class).to be < ActionCable::Connection::Base
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_all_authors_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_all_authors_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicationsHelper, type: :helper do
+  let(:other_publication) { FactoryBot.create(:other_publication) }
+
+  describe '#all_authors(publication)' do
+    it 'returns all authors for a work in a string' do
+      expect(helper.all_authors(other_publication)).to eq 'First Last, Second None '
+    end
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_author_citation_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_author_citation_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicationsHelper, type: :helper do
+  let(:other_publication) { FactoryBot.create(:other_publication) }
+
+  describe '#author_citation' do
+    context 'when no authors are present' do
+      let(:publication) { double(author_first_name: [], author_last_name: []) }
+
+      it 'returns two empty strings separated by a comma' do
+        expect(helper.author_citation(publication)).to eq(', ')
+      end
+    end
+
+    context 'when there is one author' do
+      let(:publication) { double(author_first_name: ['John'], author_last_name: ['Doe']) }
+
+      it 'returns a single author in citation format' do
+        expect(helper.author_citation(publication)).to eq('Doe, John')
+      end
+    end
+
+    context 'when there are multiple authors' do
+      let(:publication) { double(author_first_name: %w[John Jane], author_last_name: %w[Doe Roe]) }
+
+      it 'returns all authors in citation format' do
+        expect(helper.author_citation(publication)).to eq('Doe, John and Jane Roe')
+      end
+    end
+
+    context 'when publication is nil' do
+      it 'returns an empty string' do
+        expect(helper.author_citation(nil)).to eq('')
+      end
+    end
+
+    context 'when author attributes are nil' do
+      let(:publication) { double(author_first_name: nil, author_last_name: nil) }
+
+      it 'returns an empty string' do
+        expect(helper.author_citation(publication)).to eq('')
+      end
+    end
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_author_comma_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_author_comma_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicationsHelper, type: :helper do
+  let(:other_publication) { FactoryBot.create(:other_publication) }
+
+  describe '#author_comma(publication, position)' do
+    it 'returns the author comma separated for a specific position in a string' do
+      expect(helper.author_comma(other_publication, 1)).to eq 'None, Second'
+    end
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_author_name_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_author_name_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicationsHelper, type: :helper do
+  let(:other_publication) { FactoryBot.create(:other_publication) }
+
+  describe '#author_name(publication, position)' do
+    it 'returns the author for a specific position in a string' do
+      expect(helper.author_name(other_publication, 1)).to eq 'Second None'
+    end
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_author_or_artist_label_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_author_or_artist_label_spec.rb
@@ -5,24 +5,6 @@ require 'rails_helper'
 RSpec.describe PublicationsHelper, type: :helper do
   let(:other_publication) { FactoryBot.create(:other_publication) }
 
-  describe '#all_authors(publication)' do
-    it 'returns all authors for a work in a string' do
-      expect(helper.all_authors(other_publication)).to eq 'First Last, Second None '
-    end
-  end
-
-  describe '#author_name(publication, position)' do
-    it 'returns the author for a specific position in a string' do
-      expect(helper.author_name(other_publication, 1)).to eq 'Second None'
-    end
-  end
-
-  describe '#author_comma(publication, position)' do
-    it 'returns the author comma separated for a specific position in a string' do
-      expect(helper.author_comma(other_publication, 1)).to eq 'None, Second'
-    end
-  end
-
   describe '#author_or_artist_label' do
     context 'when the work is an artwork' do
       before do

--- a/spec/helpers/publications_helper/publications_helper_authors_array_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_authors_array_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicationsHelper, type: :helper do
+  let(:other_publication) { FactoryBot.create(:other_publication) }
+
+  describe '#authors_array' do
+    context 'when no authors are present' do
+      let(:publication) { double(author_first_name: [], author_last_name: []) }
+
+      it 'returns an array with an empty string' do
+        expect(helper.authors_array(publication)).to eq([' '])
+      end
+    end
+
+    context 'when there is one author' do
+      let(:publication) { double(author_first_name: ['John'], author_last_name: ['Doe']) }
+
+      it 'returns an array with a single truncated author' do
+        expect(helper.authors_array(publication)).to eq(['John Doe'])
+      end
+    end
+
+    context 'when there are multiple authors' do
+      let(:publication) { double(author_first_name: %w[John Jane], author_last_name: %w[Doe Roe]) }
+
+      it 'returns an array of truncated authors' do
+        expect(helper.authors_array(publication)).to eq(['John Doe', 'Jane Roe'])
+      end
+    end
+
+    context 'when publication is nil' do
+      it 'returns an empty array' do
+        expect(helper.authors_array(nil)).to eq([])
+      end
+    end
+
+    context 'when author attributes are nil' do
+      let(:publication) { double(author_first_name: nil, author_last_name: nil) }
+
+      it 'returns an empty array' do
+        expect(helper.authors_array(publication)).to eq([])
+      end
+    end
+
+    context 'when author names are very long' do
+      let(:long_name) { 'A' * 100 } # 100 characters
+      let(:publication) { double(author_first_name: [long_name], author_last_name: [long_name]) }
+
+      before do
+        allow(Truncato).to receive(:truncate).and_call_original
+      end
+
+      it 'truncates the author name to 12 characters plus 3 elipses' do
+        truncated_name = helper.authors_array(publication).first
+        expect(truncated_name.length).to eq(15)
+        expect(Truncato).to have_received(:truncate).with("#{long_name} #{long_name}", max_length: 12)
+        expect(truncated_name[-3..]).to eq('...') # ends with elipses
+      end
+    end
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_create_citation_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_create_citation_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicationsHelper, type: :helper do
+  let(:other_publication) { FactoryBot.create(:other_publication) }
+
+  describe '#create_citation' do
+    let(:publication) do
+      double(
+        author_first_name: ['John'],
+        author_last_name: ['Doe'],
+        other_title: 'A Study in Ruby',
+        work_title: 'Programming 101',
+        location: 'San Francisco',
+        city: '',
+        publisher: 'Ruby Press',
+        volume: '1',
+        issue: '2',
+        date: '',
+        publication_date: '2021',
+        page_numbers: '10-20',
+        doi: '',
+        url: 'http://example.com'
+      )
+    end
+
+    context 'when all attributes are present' do
+      it 'returns the complete citation string' do
+        expect(helper.create_citation(publication)).to eq(
+          'Doe, John. “A Study in Ruby”. <i>Programming 101</i>, San Francisco, Ruby Press, vol. 1, no. 2, 2021, pp. 10-20. http://example.com.'
+        )
+      end
+    end
+
+    context 'when some attributes are missing' do
+      it 'returns a citation string without the missing attributes' do
+        allow(publication).to receive(:other_title).and_return(nil)
+        expect(helper.create_citation(publication)).to eq(
+          'Doe, John. <i>Programming 101</i>, San Francisco, Ruby Press, vol. 1, no. 2, 2021, pp. 10-20. http://example.com.'
+        )
+      end
+    end
+
+    context 'when publication is nil' do
+      it 'returns nil' do
+        expect(helper.create_citation(nil)).to be_nil
+      end
+    end
+
+    context 'when multiple authors are present' do
+      it 'correctly formats multiple authors' do
+        allow(publication).to receive(:author_first_name).and_return(%w[John Jane])
+        allow(publication).to receive(:author_last_name).and_return(%w[Doe Smith])
+        expect(helper.create_citation(publication)).to include('Doe, John and Jane Smith.')
+      end
+    end
+
+    context 'when volume is present but issue is blank' do
+      it 'returns the correct string' do
+        allow(publication).to receive(:issue).and_return('')
+        expect(helper.create_citation(publication)).to include(', vol. 1, ')
+      end
+    end
+
+    context 'when DOI is present' do
+      it 'includes DOI in the citation' do
+        allow(publication).to receive(:doi).and_return('doi:12345')
+        expect(helper.create_citation(publication)).to include('. doi:12345.')
+      end
+    end
+
+    context 'when location and city both have values' do
+      it 'includes only the city' do
+        allow(publication).to receive(:city).and_return('CA')
+        allow(publication).to receive(:location).and_return('San Francisco')
+        expect(helper.create_citation(publication)).to_not include('San Francisco')
+        expect(helper.create_citation(publication)).to include('CA')
+      end
+    end
+
+    context 'when neither DOI nor URL are present' do
+      it 'omits both from the citation' do
+        allow(publication).to receive(:doi).and_return('')
+        allow(publication).to receive(:url).and_return('')
+        expect(helper.create_citation(publication)).not_to include('http://')
+        expect(helper.create_citation(publication)).not_to include('doi:')
+      end
+    end
+
+    context 'when both DOI and URL are present' do
+      it 'prioritizes DOI over URL' do
+        allow(publication).to receive(:doi).and_return('doi:12345')
+        expect(helper.create_citation(publication)).to include('. doi:12345.')
+        expect(helper.create_citation(publication)).not_to include('http://example.com')
+      end
+    end
+
+    context 'when page_numbers are blank' do
+      it 'omits page numbers from the citation' do
+        allow(publication).to receive(:page_numbers).and_return('')
+        expect(helper.create_citation(publication)).not_to include('pp.')
+      end
+    end
+
+    context 'when special characters are present in the title' do
+      it 'correctly encodes and displays special characters' do
+        allow(publication).to receive(:other_title).and_return('Study’s in Ruby')
+        # Uses the rounded apostrophe character ’ instead of the straight apostrophe '
+        expect(helper.create_citation(publication)).to include('Study’s in Ruby')
+      end
+    end
+
+    context 'when emojis are present in the title' do
+      it 'correctly includes emojis' do
+        allow(publication).to receive(:other_title).and_return('Study in Ruby 😃')
+        expect(helper.create_citation(publication)).to include('Study in Ruby 😃')
+      end
+    end
+
+    context 'when HTML-like tags are present in the title' do
+      it 'correctly encodes and displays HTML-like tags' do
+        allow(publication).to receive(:other_title).and_return('Study in <Ruby>')
+        expect(helper.create_citation(publication)).to include('Study in <Ruby>')
+      end
+    end
+
+    context 'when invalid data types are present' do
+      it 'handles it gracefully' do
+        allow(publication).to receive(:publication_date).and_return(12_345)
+        # We received a number instead of a date-time here. It should not be included in the citation.
+        expect { helper.create_citation(publication) }.to_not raise_error
+        expect(helper.create_citation(publication)).not_to include('12345')
+      end
+    end
+
+    context 'when title contains extra spaces' do
+      it 'trims the spaces' do
+        allow(publication).to receive(:other_title).and_return('  A Study in Ruby  ')
+        expect(helper.create_citation(publication)).to eq(
+          'Doe, John. “A Study in Ruby”. <i>Programming 101</i>, San Francisco, Ruby Press, vol. 1, no. 2, 2021, pp. 10-20. http://example.com.'
+        )
+      end
+    end
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_private_methods_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_private_methods_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '#preprocess_attr' do
+  include PublicationsHelper
+
+  let(:publication) do
+    double(
+      other_title: 'A Study in Ruby',
+      volume: 1,
+      some_integer: 123,
+      some_string: ' hello ',
+      nil_field: nil,
+      empty_string: ''
+    )
+  end
+
+  context 'when the attribute exists and is non-blank' do
+    it 'returns the attribute value' do
+      expect(preprocess_attr(publication, :other_title)).to eq('A Study in Ruby')
+    end
+
+    it 'strips extra spaces if the attribute is a string' do
+      expect(preprocess_attr(publication, :some_string)).to eq('hello')
+    end
+
+    it 'returns nil if the attribute is a number' do
+      expect(preprocess_attr(publication, :volume)).to eq(nil)
+    end
+  end
+
+  context 'when the attribute exists but is blank' do
+    it 'returns nil for an empty string' do
+      expect(preprocess_attr(publication, :empty_string)).to eq(nil)
+    end
+
+    it 'returns nil for a nil value' do
+      expect(preprocess_attr(publication, :nil_field)).to eq(nil)
+    end
+  end
+
+  context 'when the attribute does not exist' do
+    it 'returns nil' do
+      expect(preprocess_attr(publication, :non_existent_field)).to eq(nil)
+    end
+  end
+
+  context 'when multiple attributes are provided' do
+    it 'returns the first non-blank attribute' do
+      expect(preprocess_attr(publication, :nil_field, :empty_string, :some_string)).to eq('hello')
+    end
+
+    it 'returns nil if all attributes are blank or do not exist' do
+      expect(preprocess_attr(publication, :nil_field, :empty_string, :non_existent_field)).to eq(nil)
+    end
+  end
+end

--- a/spec/helpers/publications_helper/publications_helper_publications_id_spec.rb
+++ b/spec/helpers/publications_helper/publications_helper_publications_id_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicationsHelper, type: :helper do
+  let(:other_publication) { FactoryBot.create(:other_publication) }
+
+  describe '#publications_id' do
+    context 'when given a valid id' do
+      let(:id) { 1 }
+
+      it 'returns the correct path' do
+        expect(helper.publications_id(id)).to eq("/publications/#{id}")
+      end
+    end
+
+    context 'when given an id as a string' do
+      let(:id) { '1' }
+
+      it 'returns the correct path' do
+        expect(helper.publications_id(id)).to eq("/publications/#{id}")
+      end
+    end
+
+    context 'when given a nil id' do
+      it 'returns the correct path' do
+        expect(helper.publications_id(nil)).to eq('/publications/')
+      end
+    end
+  end
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ApplicationJob, type: :job do

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationJob, type: :job do
+  it 'inherits from ActiveJob::Base' do
+    expect(described_class.ancestors).to include(ActiveJob::Base)
+  end
+end


### PR DESCRIPTION
Fixes #131

Increase test coverage to over 95% per Coveralls.

The "channels" classes and jobs/applications_job didn't have any tests, as they were simply blank models.  I was not 100% certain that we were not using these models somewhere or having the intent to use them in the future, so I made a couple of tests that simply checked if they were inheriting from the correct classes.

The helper "publications_helper" had a bunch of functions in it that didn't have any tests.  Created a folder at spec/helpers/publications_helper/ and created a file for each function contained within the helper.

Rewrote the "create_citation" function to improve readability and added extra validation checks for author_citation and authors_array.
