### PR TITLE
Add confirmation check to deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -55,3 +55,32 @@ task :ruby_update_check do
     execute "cd #{fetch(:release_path)}/ && chmod a+x scripts/* && source scripts/check_ruby.sh"
   end
 end
+
+namespace :deploy do
+  task :confirmation do
+    stage = fetch(:stage).upcase
+    branch = fetch(:branch)
+    puts <<-WARN
+
+    ========================================================================
+
+      *** Deploying branch `#{branch}` to #{stage} server ***
+
+      WARNING: You're about to perform actions on #{stage} server(s)
+      Please confirm that all your intentions are kind and friendly
+
+    ========================================================================
+
+    WARN
+    ask :value, "Sure you want to continue deploying `#{branch}` on #{stage}? (Y or Yes)"
+
+    unless fetch(:value).match?(/\A(?i:yes|y)\z/)
+      puts "\nNo confirmation - deploy cancelled!"
+      exit
+    end
+  end
+end
+
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'deploy:confirmation'
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -10,6 +10,11 @@ append :linked_dirs, 'tmp', 'log'
 ask(:username, nil)
 ask(:password, nil, echo: false)
 server 'libapps.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22, roles: %i[web app db]
+ask(:value, 'Have you submitted and received an approved Change Management Request? (Y or Yes)')
+unless fetch(:value).match?(/\A(?i:yes|y)\z/)
+  puts "\nNo confirmation - deploy cancelled!"
+  exit
+end
 set :deploy_to, '/opt/webapps/aaec'
 after 'deploy:updating', 'ruby_update_check'
 after 'deploy:updating', 'init_qp'


### PR DESCRIPTION
Fixes #218 

Add general confirmation check for deploy on all modes and change request check on production deploys.

