### PR TITLE
228 - fixed hamburger drop-down menu (broken data-toggle="collapse" tag)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,6 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <script src='https://kit.fontawesome.com/a076d05399.js'></script>
-    <!--this is the old link <link href="//stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">-->
-    <!--changed reference to font-awesome to use the new link below-->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css">
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 
@@ -42,7 +40,7 @@
         </svg>
     </a>
 
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNavDropdown">


### PR DESCRIPTION
Fixes #228 

Fixed non-working hamburger menu on header

When we migrated to Bootstrap 5.0, two data commands were changed:

1. `data-toggle` changed to `data-bs-toggle`
2. `data-target` changed to `data-bs-target`

These commands didn't get updated in application.html.erb, so the hamburger menu stopped functioning.

Note:  there are an additional 43 instances of "data-toggle" in the app that I am leaving in place.  This is because they are all linked to this:
```
$(document).on('turbolinks:load', function() {
    $('[data-toggle="tooltip"]').tooltip();
})
```
The above is successfully adding a tooltip when we hover over items tagged with `data-toggle="tooltip"`, so it didn't seem necessary to me to update them.  