### PR TITLE
WIP - 238 restrict page access to logged in

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,7 +3,7 @@
 class AdminController < ApplicationController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   skip_before_action :require_authenticated_user, only: %i[login validate]
   skip_before_action :check_date
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class AdminController < ApplicationController
+  include UserAuthentication
+  skip_before_action :require_authenticated_user, only: %i[login validate]
+  skip_before_action :set_cache_headers, only: %i[login validate]
   skip_before_action :check_date
 
   ALLOWED_CONTROLLERS_TO_MODELS = {

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -31,7 +31,8 @@ class AdminController < ApplicationController
       session[:admin] = true
       redirect_to publications_path
     else
-      redirect_to manage_path, notice: 'Invalid Credentails'
+      flash.keep[:danger] = 'Invalid Credentails'
+      redirect_to manage_path
     end
   end
 
@@ -46,7 +47,8 @@ class AdminController < ApplicationController
       end
     rescue StandardError => e
       logger.error "CSV generation failed: #{e}"
-      redirect_to publications_path, notice: 'Something went wrong while generating the CSV.'
+      flash.keep[:danger] = 'Something went wrong while generating the CSV.'
+      redirect_to publications_path
     end
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -35,31 +35,25 @@ class AdminController < ApplicationController
   end
 
   def csv
-    if session[:admin] && params[:id].nil? && allowed_model
-      begin
-        @instance_variable = allowed_model.all
-        respond_to do |format|
-          format.html { redirect_to publications_path }
-          format.csv { send_data @instance_variable.to_csv }
-        end
-      rescue StandardError => e
-        logger.error "CSV generation failed: #{e}"
-        redirect_to publications_path, notice: 'Something went wrong while generating the CSV.'
+    redirect_to publications_path if params[:id] || !allowed_model
+
+    begin
+      @instance_variable = allowed_model.all
+      respond_to do |format|
+        format.html { redirect_to publications_path }
+        format.csv { send_data @instance_variable.to_csv }
       end
-    else
-      redirect_to publications_path
+    rescue StandardError => e
+      logger.error "CSV generation failed: #{e}"
+      redirect_to publications_path, notice: 'Something went wrong while generating the CSV.'
     end
   end
 
   def citations
-    if session[:admin]
-      all = fetch_all_records
-      @college_array = []
-      (1..College.count).each do |i|
-        @college_array << [i, all.select { |p| p.respond_to?(:college_ids) && p.college_ids.include?(i) }.group_by(&:uc_department)]
-      end
-    else
-      redirect_to publications_path
+    all = fetch_all_records
+    @college_array = []
+    (1..College.count).each do |i|
+      @college_array << [i, all.select { |p| p.respond_to?(:college_ids) && p.college_ids.include?(i) }.group_by(&:uc_department)]
     end
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,8 +2,9 @@
 
 class AdminController < ApplicationController
   include UserAuthentication
+  include CacheHeaderControl
+  
   skip_before_action :require_authenticated_user, only: %i[login validate]
-  skip_before_action :set_cache_headers, only: %i[login validate]
   skip_before_action :check_date
 
   ALLOWED_CONTROLLERS_TO_MODELS = {

--- a/app/controllers/artworks_controller.rb
+++ b/app/controllers/artworks_controller.rb
@@ -2,7 +2,8 @@
 
 class ArtworksController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:artwork).permit(:uc_department, :other_college, :work_title, :other_title, :location, :date, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/artworks_controller.rb
+++ b/app/controllers/artworks_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ArtworksController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:artwork).permit(:uc_department, :other_college, :work_title, :other_title, :location, :date, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/artworks_controller.rb
+++ b/app/controllers/artworks_controller.rb
@@ -3,7 +3,7 @@
 class ArtworksController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:artwork).permit(:uc_department, :other_college, :work_title, :other_title, :location, :date, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/book_chapters_controller.rb
+++ b/app/controllers/book_chapters_controller.rb
@@ -2,7 +2,8 @@
 
 class BookChaptersController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:book_chapter).permit(:uc_department, :other_college, :work_title, :other_title, :page_numbers, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/book_chapters_controller.rb
+++ b/app/controllers/book_chapters_controller.rb
@@ -3,7 +3,7 @@
 class BookChaptersController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:book_chapter).permit(:uc_department, :other_college, :work_title, :other_title, :page_numbers, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/book_chapters_controller.rb
+++ b/app/controllers/book_chapters_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BookChaptersController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:book_chapter).permit(:uc_department, :other_college, :work_title, :other_title, :page_numbers, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BooksController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:book).permit(:uc_department, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :other_college, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,7 +3,7 @@
 class BooksController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:book).permit(:uc_department, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :other_college, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -2,7 +2,8 @@
 
 class BooksController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:book).permit(:uc_department, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :other_college, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/colleges_controller.rb
+++ b/app/controllers/colleges_controller.rb
@@ -2,7 +2,8 @@
 
 class CollegesController < ApplicationController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   before_action :set_college, only: %i[show edit update destroy]
 
   # GET /colleges

--- a/app/controllers/colleges_controller.rb
+++ b/app/controllers/colleges_controller.rb
@@ -31,7 +31,8 @@ class CollegesController < ApplicationController
 
     respond_to do |format|
       if @college.save
-        format.html { redirect_to @college, notice: 'College was successfully created.' }
+        flash.keep[:success] = 'College was successfully created.'
+        format.html { redirect_to @college }
         format.json { render :show, status: :created, location: @college }
       else
         format.html { render :new }
@@ -45,7 +46,8 @@ class CollegesController < ApplicationController
   def update
     respond_to do |format|
       if @college.update(college_params)
-        format.html { redirect_to @college, notice: 'College was successfully updated.' }
+        flash.keep[:success] = 'College was successfully updated.'
+        format.html { redirect_to @college }
         format.json { render :show, status: :ok, location: @college }
       else
         format.html { render :edit }
@@ -59,7 +61,8 @@ class CollegesController < ApplicationController
   def destroy
     @college.destroy
     respond_to do |format|
-      format.html { redirect_to colleges_url, notice: 'College was successfully destroyed.' }
+      flash.keep[:warning] = 'College was successfully destroyed.'
+      format.html { redirect_to colleges_url }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/colleges_controller.rb
+++ b/app/controllers/colleges_controller.rb
@@ -3,7 +3,7 @@
 class CollegesController < ApplicationController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   before_action :set_college, only: %i[show edit update destroy]
 
   # GET /colleges

--- a/app/controllers/colleges_controller.rb
+++ b/app/controllers/colleges_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CollegesController < ApplicationController
+  include UserAuthentication
+
   before_action :set_college, only: %i[show edit update destroy]
 
   # GET /colleges

--- a/app/controllers/concerns/cache_header_control.rb
+++ b/app/controllers/concerns/cache_header_control.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# The CacheHeaderControl module is a Rails Concern designed to control the cache behavior
+# of the HTTP responses from the controllers where it's included.
+# This module sets specific HTTP headers to prevent the browser and any intermediate proxies
+# from caching the response, ensuring that sensitive or dynamic data is not cached.
+#
+# Usage:
+#
+# Include this module in any Rails controller where you want to disable client-side caching.
+# This will automatically add a before_action that sets appropriate cache control headers.
+#
+# Example:
+#
+# class SomeController < ApplicationController
+#   include CacheHeaderControl
+#   ...
+# end
+#
+module CacheHeaderControl
+  extend ActiveSupport::Concern
+
+  included do
+    puts "CacheHeaderControl included in #{self.name}"
+    before_action :set_cache_headers
+  end
+
+  private
+
+  def set_cache_headers
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+  end
+end

--- a/app/controllers/concerns/cache_header_control.rb
+++ b/app/controllers/concerns/cache_header_control.rb
@@ -21,14 +21,13 @@ module CacheHeaderControl
   extend ActiveSupport::Concern
 
   included do
-    puts "CacheHeaderControl included in #{self.name}"
     before_action :set_cache_headers
   end
 
   private
 
   def set_cache_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Cache-Control'] = 'no-cache'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
   end

--- a/app/controllers/concerns/user_authentication.rb
+++ b/app/controllers/concerns/user_authentication.rb
@@ -20,7 +20,7 @@
 #
 # This will add the following before actions to the controller:
 # - `require_authenticated_user`: Ensures that a user is authenticated.
-# 
+#
 #
 module UserAuthentication
   extend ActiveSupport::Concern

--- a/app/controllers/concerns/user_authentication.rb
+++ b/app/controllers/concerns/user_authentication.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# UserAuthentication Module
+#
+# This module is intended to be included in controllers that require
+# user authentication and admin check functionalities.
+#
+# It adds a `before_action` that ensures a user is authenticated as either
+# an admin or a regular submitter before accessing any action in the
+# controller.
+#
+# Example:
+#   class SomeController < ApplicationController
+#     include UserAuthentication
+#     ...
+#   end
+#
+module UserAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_authenticated_user
+    before_action :set_cache_headers
+  end
+
+  private
+
+  def require_authenticated_user
+    return if admin_logged_in? || current_submitter
+
+    redirect_to root_path, alert: 'You must submit your information first.'
+  end
+
+  def admin_logged_in?
+    session[:admin]
+  end
+
+  def current_submitter
+    @current_submitter ||= Submitter.find_by(id: session[:submitter_id])
+  end
+
+  def set_cache_headers
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
+  end
+end

--- a/app/controllers/concerns/user_authentication.rb
+++ b/app/controllers/concerns/user_authentication.rb
@@ -34,13 +34,15 @@ module UserAuthentication
 
   def handle_invalid_token
     reset_session
-    redirect_to root_path, alert: 'Your session has expired. Please log in again.'
+    flash.keep[:danger] = 'Your session has expired. Please log in again.'
+    redirect_to root_path
   end
 
   def require_authenticated_user
     return if admin_logged_in? || current_submitter
 
-    redirect_to root_path, alert: 'You must submit your information first.'
+    flash.keep[:danger] = 'You must submit your information first.'
+    redirect_to root_path
   end
 
   def admin_logged_in?

--- a/app/controllers/concerns/user_authentication.rb
+++ b/app/controllers/concerns/user_authentication.rb
@@ -2,12 +2,14 @@
 
 # UserAuthentication Module
 #
-# This module is intended to be included in controllers that require
-# user authentication and admin check functionalities.
+# This ActiveSupport::Concern module is designed to be included in Rails controllers
+# to provide user authentication features. Once included, it automatically adds
+# before actions to enforce user authentication.
 #
-# It adds a `before_action` that ensures a user is authenticated as either
-# an admin or a regular submitter before accessing any action in the
-# controller.
+# ## Usage
+#
+# To use this module, include it at the top of any Rails controller where you
+# want to enforce user authentication:
 #
 # Example:
 #   class SomeController < ApplicationController
@@ -15,12 +17,16 @@
 #     ...
 #   end
 #
+#
+# This will add the following before actions to the controller:
+# - `require_authenticated_user`: Ensures that a user is authenticated.
+# 
+#
 module UserAuthentication
   extend ActiveSupport::Concern
 
   included do
     before_action :require_authenticated_user
-    before_action :set_cache_headers
   end
 
   private
@@ -37,11 +43,5 @@ module UserAuthentication
 
   def current_submitter
     @current_submitter ||= Submitter.find_by(id: session[:submitter_id])
-  end
-
-  def set_cache_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-    response.headers['Pragma'] = 'no-cache'
-    response.headers['Expires'] = 'Fri, 01 Jan 1990 00:00:00 GMT'
   end
 end

--- a/app/controllers/concerns/user_authentication.rb
+++ b/app/controllers/concerns/user_authentication.rb
@@ -26,10 +26,16 @@ module UserAuthentication
   extend ActiveSupport::Concern
 
   included do
+    rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_token
     before_action :require_authenticated_user
   end
 
   private
+
+  def handle_invalid_token
+    reset_session
+    redirect_to root_path, alert: 'Your session has expired. Please log in again.'
+  end
 
   def require_authenticated_user
     return if admin_logged_in? || current_submitter

--- a/app/controllers/digital_projects_controller.rb
+++ b/app/controllers/digital_projects_controller.rb
@@ -3,7 +3,7 @@
 class DigitalProjectsController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:digital_project).permit(:uc_department, :other_college, :work_title, :other_title, :name_of_site, :name_of_affiliated_organization, :publication_date, :version, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/digital_projects_controller.rb
+++ b/app/controllers/digital_projects_controller.rb
@@ -2,7 +2,8 @@
 
 class DigitalProjectsController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:digital_project).permit(:uc_department, :other_college, :work_title, :other_title, :name_of_site, :name_of_affiliated_organization, :publication_date, :version, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/digital_projects_controller.rb
+++ b/app/controllers/digital_projects_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DigitalProjectsController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:digital_project).permit(:uc_department, :other_college, :work_title, :other_title, :name_of_site, :name_of_affiliated_organization, :publication_date, :version, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/editings_controller.rb
+++ b/app/controllers/editings_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EditingsController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:editing).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/editings_controller.rb
+++ b/app/controllers/editings_controller.rb
@@ -2,7 +2,8 @@
 
 class EditingsController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:editing).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/editings_controller.rb
+++ b/app/controllers/editings_controller.rb
@@ -3,7 +3,7 @@
 class EditingsController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:editing).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,7 +3,7 @@
 # app/controllers/errors_controller.rb
 class ErrorsController < ApplicationController
   include UserAuthentication
-  
+
   # Per Infosec, all errors should route to the 404 page, not the 422 or 500 pages.
   def not_found
     render template: 'errors/404', layout: 'application', status: :not_found

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,7 +3,7 @@
 # app/controllers/errors_controller.rb
 class ErrorsController < ApplicationController
   include UserAuthentication
-
+  
   # Per Infosec, all errors should route to the 404 page, not the 422 or 500 pages.
   def not_found
     render template: 'errors/404', layout: 'application', status: :not_found

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,8 @@
 
 # app/controllers/errors_controller.rb
 class ErrorsController < ApplicationController
+  include UserAuthentication
+
   # Per Infosec, all errors should route to the 404 page, not the 422 or 500 pages.
   def not_found
     render template: 'errors/404', layout: 'application', status: :not_found

--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -2,7 +2,8 @@
 
 class FilmsController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:film).permit(:uc_department, :other_college, :work_title, :other_title, :producer, :director, :release_year, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FilmsController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:film).permit(:uc_department, :other_college, :work_title, :other_title, :producer, :director, :release_year, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -3,7 +3,7 @@
 class FilmsController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:film).permit(:uc_department, :other_college, :work_title, :other_title, :producer, :director, :release_year, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/journal_articles_controller.rb
+++ b/app/controllers/journal_articles_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class JournalArticlesController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:journal_article).permit(:uc_department, :other_college, :work_title, :other_title, :volume, :issue, :page_numbers, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/journal_articles_controller.rb
+++ b/app/controllers/journal_articles_controller.rb
@@ -3,7 +3,7 @@
 class JournalArticlesController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:journal_article).permit(:uc_department, :other_college, :work_title, :other_title, :volume, :issue, :page_numbers, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/journal_articles_controller.rb
+++ b/app/controllers/journal_articles_controller.rb
@@ -2,7 +2,8 @@
 
 class JournalArticlesController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:journal_article).permit(:uc_department, :other_college, :work_title, :other_title, :volume, :issue, :page_numbers, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/musical_scores_controller.rb
+++ b/app/controllers/musical_scores_controller.rb
@@ -2,7 +2,8 @@
 
 class MusicalScoresController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:musical_score).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/musical_scores_controller.rb
+++ b/app/controllers/musical_scores_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MusicalScoresController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:musical_score).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/musical_scores_controller.rb
+++ b/app/controllers/musical_scores_controller.rb
@@ -3,7 +3,7 @@
 class MusicalScoresController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:musical_score).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/other_publications_controller.rb
+++ b/app/controllers/other_publications_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class OtherPublicationsController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:other_publication).permit(:uc_department, :work_title, :other_title, :volume, :issue, :page_numbers, :publisher, :city, :publication_date, :url, :doi, :other_college, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/other_publications_controller.rb
+++ b/app/controllers/other_publications_controller.rb
@@ -2,7 +2,8 @@
 
 class OtherPublicationsController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:other_publication).permit(:uc_department, :work_title, :other_title, :volume, :issue, :page_numbers, :publisher, :city, :publication_date, :url, :doi, :other_college, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/other_publications_controller.rb
+++ b/app/controllers/other_publications_controller.rb
@@ -3,7 +3,7 @@
 class OtherPublicationsController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:other_publication).permit(:uc_department, :work_title, :other_title, :volume, :issue, :page_numbers, :publisher, :city, :publication_date, :url, :doi, :other_college, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,8 @@
 
 # app/controllers/pages_controller.rb
 class PagesController < ApplicationController
+  include UserAuthentication
+
   skip_before_action :check_date
   ALLOWED_PAGES = %w[closed finished].freeze
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@
 class PagesController < ApplicationController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   skip_before_action :check_date
   ALLOWED_PAGES = %w[closed finished].freeze
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,8 @@
 # app/controllers/pages_controller.rb
 class PagesController < ApplicationController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   skip_before_action :check_date
   ALLOWED_PAGES = %w[closed finished].freeze
 

--- a/app/controllers/photographies_controller.rb
+++ b/app/controllers/photographies_controller.rb
@@ -3,7 +3,7 @@
 class PhotographiesController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:photography).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/photographies_controller.rb
+++ b/app/controllers/photographies_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PhotographiesController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:photography).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/photographies_controller.rb
+++ b/app/controllers/photographies_controller.rb
@@ -2,7 +2,8 @@
 
 class PhotographiesController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:photography).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/physical_media_controller.rb
+++ b/app/controllers/physical_media_controller.rb
@@ -3,7 +3,7 @@
 class PhysicalMediaController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:physical_medium).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/physical_media_controller.rb
+++ b/app/controllers/physical_media_controller.rb
@@ -2,7 +2,8 @@
 
 class PhysicalMediaController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:physical_medium).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/physical_media_controller.rb
+++ b/app/controllers/physical_media_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PhysicalMediaController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:physical_medium).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/plays_controller.rb
+++ b/app/controllers/plays_controller.rb
@@ -2,7 +2,8 @@
 
 class PlaysController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:play).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/plays_controller.rb
+++ b/app/controllers/plays_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PlaysController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:play).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/plays_controller.rb
+++ b/app/controllers/plays_controller.rb
@@ -3,7 +3,7 @@
 class PlaysController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:play).permit(:uc_department, :other_college, :work_title, :other_title, :publisher, :city, :publication_date, :url, :doi, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/public_performances_controller.rb
+++ b/app/controllers/public_performances_controller.rb
@@ -3,7 +3,7 @@
 class PublicPerformancesController < PublicationsController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:public_performance).permit(:uc_department, :other_college, :work_title, :other_title, :location, :time, :date, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/public_performances_controller.rb
+++ b/app/controllers/public_performances_controller.rb
@@ -2,7 +2,8 @@
 
 class PublicPerformancesController < PublicationsController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:public_performance).permit(:uc_department, :other_college, :work_title, :other_title, :location, :time, :date, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/public_performances_controller.rb
+++ b/app/controllers/public_performances_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PublicPerformancesController < PublicationsController
+  include UserAuthentication
+
   # Never trust parameters from the scary internet, only allow the white list through.
   def allowed_params
     params.require(:public_performance).permit(:uc_department, :other_college, :work_title, :other_title, :location, :time, :date, :submitter_id, author_first_name: [], author_last_name: [], college_ids: [])

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -26,8 +26,10 @@
 #
 
 class PublicationsController < ApplicationController
+  include UserAuthentication
+
   before_action :set_object, only: %i[show edit update destroy]
-  before_action :signed_in, only: %i[index show edit update destroy]
+  # before_action :signed_in, only: %i[index show edit update destroy]
   before_action :check_max_submissions, only: %i[new]
 
   def index

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -21,7 +21,6 @@
 #
 # Filters:
 # - set_object: Sets the object based on the controller name and params[:id].
-# - signed_in: Checks if the user is signed in before granting access to certain actions.
 # - check_max_submissions: Checks if the maximum submission limit is reached for a given user.
 #
 
@@ -29,7 +28,6 @@ class PublicationsController < ApplicationController
   include UserAuthentication
 
   before_action :set_object, only: %i[show edit update destroy]
-  # before_action :signed_in, only: %i[index show edit update destroy]
   before_action :check_max_submissions, only: %i[new]
 
   def index
@@ -161,10 +159,6 @@ class PublicationsController < ApplicationController
 
   def set_object
     instance_variable_set("@#{controller_name.singularize}", Object.const_get(controller_name.classify).find(params[:id]))
-  end
-
-  def signed_in
-    redirect_to root_path unless session[:admin] || session[:submitter_id]
   end
 
   def check_max_submissions

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -125,7 +125,8 @@ class PublicationsController < ApplicationController
     respond_to do |format|
       if instance_variable.save
         PublicationMailer.publication_submit(helpers.find_submitter(session[:submitter_id]), instance_variable).deliver_now
-        format.html { redirect_to publications_path, notice: "#{controller_name.classify} was successfully created." }
+        flash.keep[:success] = "#{controller_name.classify} was successfully created."
+        format.html { redirect_to publications_path }
         format.json { render :show, status: :created, location: instance_variable }
       else
         format.html { render :new }
@@ -138,7 +139,8 @@ class PublicationsController < ApplicationController
     instance_variable = instance_variable_get("@#{controller_name.singularize}")
     respond_to do |format|
       if instance_variable.update(allowed_params)
-        format.html { redirect_to instance_variable, notice: "#{controller_name.classify} was successfully updated." }
+        flash.keep[:success] = "#{controller_name.classify} was successfully updated."
+        format.html { redirect_to instance_variable }
         format.json { render :show, status: :created, location: instance_variable }
       else
         format.html { render :new }
@@ -151,7 +153,8 @@ class PublicationsController < ApplicationController
     instance_variable = instance_variable_get("@#{controller_name.singularize}")
     instance_variable.destroy
     respond_to do |format|
-      format.html { redirect_to instance_variable, notice: "#{controller_name.classify} was successfully destroyed." }
+      flash.keep[:warning] = "#{controller_name.classify} was successfully destroyed."
+      format.html { redirect_to instance_variable }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -26,7 +26,8 @@
 
 class PublicationsController < ApplicationController
   include UserAuthentication
-
+  include CacheHeaderControl
+  
   before_action :set_object, only: %i[show edit update destroy]
   before_action :check_max_submissions, only: %i[new]
 

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -27,7 +27,7 @@
 class PublicationsController < ApplicationController
   include UserAuthentication
   include CacheHeaderControl
-  
+
   before_action :set_object, only: %i[show edit update destroy]
   before_action :check_max_submissions, only: %i[new]
 

--- a/app/controllers/submitters_controller.rb
+++ b/app/controllers/submitters_controller.rb
@@ -30,7 +30,8 @@ class SubmittersController < ApplicationController
         reset_session
         session[:submitter_id] = @submitter.id
         # Change to home page
-        format.html { redirect_to publications_path, notice: 'Your account was successfully created.' }
+        flash.keep[:success] = 'Your account was successfully created.'
+        format.html { redirect_to publications_path }
         format.json { render :show, status: :created, location: @submitter }
       else
         format.html { render :new }
@@ -44,7 +45,8 @@ class SubmittersController < ApplicationController
   def update
     respond_to do |format|
       if @submitter.update(submitter_params)
-        format.html { redirect_to publications_path, notice: 'Your account was successfully updated.' }
+        flash.keep[:success] = 'Your account was successfully updated.'
+        format.html { redirect_to publications_path }
         format.json { render :show, status: :ok, location: @submitter }
       else
         format.html { render :edit }

--- a/app/controllers/submitters_controller.rb
+++ b/app/controllers/submitters_controller.rb
@@ -26,6 +26,8 @@ class SubmittersController < ApplicationController
 
     respond_to do |format|
       if @submitter.save
+        # Reset the session to prevent session fixation attacks.
+        reset_session
         session[:submitter_id] = @submitter.id
         # Change to home page
         format.html { redirect_to publications_path, notice: 'Your account was successfully created.' }

--- a/app/controllers/submitters_controller.rb
+++ b/app/controllers/submitters_controller.rb
@@ -2,9 +2,9 @@
 
 class SubmittersController < ApplicationController
   include UserAuthentication
-  skip_before_action :require_authenticated_user, only: %i[new create]
-  skip_before_action :set_cache_headers, only: %i[new create]
+  include CacheHeaderControl
 
+  skip_before_action :require_authenticated_user, only: %i[new create]
   before_action :set_submitter, only: %i[show edit update destroy]
 
   # GET /submitters/1

--- a/app/controllers/submitters_controller.rb
+++ b/app/controllers/submitters_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class SubmittersController < ApplicationController
+  include UserAuthentication
+  skip_before_action :require_authenticated_user, only: %i[new create]
+  skip_before_action :set_cache_headers, only: %i[new create]
+
   before_action :set_submitter, only: %i[show edit update destroy]
 
   # GET /submitters/1

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,6 @@
 module ApplicationHelper
   include Pagy::Frontend
 
-
   def shorten_long(input)
     input_array = input.strip.split(/\s+/)
     return_string = ''

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,9 +3,6 @@
 module ApplicationHelper
   include Pagy::Frontend
 
-  def signed_in
-    session[:admin] || session[:submitter_id]
-  end
 
   def shorten_long(input)
     input_array = input.strip.split(/\s+/)

--- a/app/views/admin/_form.html.erb
+++ b/app/views/admin/_form.html.erb
@@ -2,14 +2,14 @@
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label :username %>
-      <%= form.text_field :username, required: true, class: "form-control" %>
+      <%= form.text_field :username, required: true, class: "form-control", autocomplete: 'off' %>
     </div>
   </div>
 
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label :password %>
-      <%= form.text_field :password, type: "password",required: true, class: "form-control" %>
+      <%= form.text_field :password, type: "password",required: true, class: "form-control", autocomplete: 'off' %>
     </div>
   </div>
 

--- a/app/views/admin/login.html.erb
+++ b/app/views/admin/login.html.erb
@@ -1,10 +1,4 @@
 <div class="container offset-footer">
-    <% if notice %>
-        <div class="alert alert-danger" role="alert">
-            <%= notice %>
-        </div>
-    <% end %>
-
     <div class="row pl-2">
         <h1>Admin Login</h1>
     </div>

--- a/app/views/artworks/show.html.erb
+++ b/app/views/artworks/show.html.erb
@@ -1,11 +1,5 @@
 <div class="container offset-footer">
 
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Artwork</h1>
   </div>

--- a/app/views/book_chapters/show.html.erb
+++ b/app/views/book_chapters/show.html.erb
@@ -1,11 +1,5 @@
 <div class="container offset-footer">
 
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Book Chapter</h1>
   </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,11 +1,5 @@
 <div class="container offset-footer">
 
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Book</h1>
   </div>

--- a/app/views/colleges/index.html.erb
+++ b/app/views/colleges/index.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Colleges</h1>
 </div>

--- a/app/views/colleges/show.html.erb
+++ b/app/views/colleges/show.html.erb
@@ -1,11 +1,5 @@
 <div class="container offset-footer">
 
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show College</h1>
   </div>

--- a/app/views/digital_projects/show.html.erb
+++ b/app/views/digital_projects/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Digital Project</h1>
   </div>

--- a/app/views/editings/show.html.erb
+++ b/app/views/editings/show.html.erb
@@ -1,11 +1,5 @@
 <div class="container offset-footer">
 
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Editing</h1>
   </div>

--- a/app/views/films/show.html.erb
+++ b/app/views/films/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Film</h1>
   </div>

--- a/app/views/journal_articles/show.html.erb
+++ b/app/views/journal_articles/show.html.erb
@@ -1,11 +1,5 @@
 <div class="container offset-footer">
 
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Journal Article</h1>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,6 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css">
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-
-
   </head>
 
   <body>
@@ -64,6 +62,14 @@
       <div class="container">
         <%= link_to "LIBRARIES", "https://libraries.uc.edu/", target: "_blank", class: "text-white" %>
       </div>
+    </div>
+    <div class="container offset-footer">
+      <% flash.each do |type, message| %>
+        <br/>
+        <div class="alert alert-<%= type %>" role="alert">
+          <%= message %>
+        </div>
+      <% end %>
     </div>
     <%= yield %>
     <%= render partial: 'layouts/footer' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <script src='https://kit.fontawesome.com/a076d05399.js'></script>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css">
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,6 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNavDropdown">
         <ul class="navbar-nav">
-          <% if signed_in %>
           <li class="nav-item">
             <% if session[:admin] then @link_text = "All Publications" else @link_text = "My Publications" end %>
             <%= link_to @link_text, publications_path, class: "nav-link text-white", id: "publications_link"%>
@@ -58,7 +57,6 @@
           <li class="nav-item">
             <%= link_to "I'm Finished", finished_path, class: "nav-link text-white" %>
           </li>
-        <% end %>
         </ul>
       </div>
       </div>

--- a/app/views/musical_scores/show.html.erb
+++ b/app/views/musical_scores/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Musical Score</h1>
   </div>

--- a/app/views/other_publications/show.html.erb
+++ b/app/views/other_publications/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Other Publication</h1>
   </div>

--- a/app/views/photographies/show.html.erb
+++ b/app/views/photographies/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Photography</h1>
   </div>

--- a/app/views/physical_media/show.html.erb
+++ b/app/views/physical_media/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Physical Medium</h1>
   </div>

--- a/app/views/plays/show.html.erb
+++ b/app/views/plays/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Play</h1>
   </div>

--- a/app/views/public_performances/show.html.erb
+++ b/app/views/public_performances/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Public Performance</h1>
   </div>

--- a/app/views/submitters/_form.html.erb
+++ b/app/views/submitters/_form.html.erb
@@ -12,37 +12,37 @@
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label :first_name, 'First Name', class: "required" %>
-      <%= form.text_field :first_name, required: true, class: "form-control" %>
+      <%= form.text_field :first_name, required: true, class: "form-control", autocomplete: 'off' %>
     </div>
 
     <div class="form-group col-md-6">
       <%= form.label :last_name, 'Last Name', class: "required" %>
-      <%= form.text_field :last_name, required: true, class: "form-control" %>
+      <%= form.text_field :last_name, required: true, class: "form-control", autocomplete: 'off' %>
     </div>
   </div>
 
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label(:college, "UC College") %>
-      <%= select_tag "submitter[college]", options_from_collection_for_select(College.all, :id, :name, @submitter.college), prompt: "Please select a college", class: "form-control" %>
+      <%= select_tag "submitter[college]", options_from_collection_for_select(College.all, :id, :name, @submitter.college), prompt: "Please select a college", class: "form-control", autocomplete: 'off' %>
       <small class="form-text text-muted">If "Other", enter your college and department in the UC Department field</small>
     </div>
 
     <div class="form-group col-md-6">
       <%= form.label(:department, "UC Department or Division") %>
-      <%= form.text_field :department, class: "form-control" %>
+      <%= form.text_field :department, class: "form-control", autocomplete: 'off' %>
     </div>
   </div>
 
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label(:mailing_address, "Mail Location (Postal address if off campus)", class: "required") %>
-      <%= form.text_field :mailing_address, required: true, class: "form-control" %>
+      <%= form.text_field :mailing_address, required: true, class: "form-control", autocomplete: 'off' %>
     </div>
 
     <div class="form-group col-md-6">
       <%= form.label :phone_number, 'Phone Number', class: "required" %>
-      <%= form.text_field :phone_number, required: true, class: "form-control" %>
+      <%= form.text_field :phone_number, required: true, class: "form-control", autocomplete: 'off' %>
       <small class="form-text text-muted">Must be in the form ###-###-####</small>
     </div>
   </div>
@@ -50,7 +50,7 @@
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label(:email_address, "Email Address", class: "required") %>
-      <%= form.text_field :email_address, required: true, class: "form-control" %>
+      <%= form.text_field :email_address, required: true, class: "form-control", autocomplete: 'off' %>
     </div>
   </div>
 

--- a/app/views/submitters/new.html.erb
+++ b/app/views/submitters/new.html.erb
@@ -1,5 +1,4 @@
 <div class="container offset-footer">
-
     <div class="row pl-2">
         <h1>Artists, Authors, Editors & Composers</h1>
     </div>

--- a/app/views/submitters/show.html.erb
+++ b/app/views/submitters/show.html.erb
@@ -1,11 +1,4 @@
 <div class="container offset-footer">
-
-  <% if notice %>
-  <div class="alert alert-success" role="alert">
-    <%= notice %>
-  </div>
-  <% end %>
-
   <div class="row pl-2">
     <h1>Show Submitter</h1>
   </div>

--- a/spec/controllers/admin_controller/admin_controller_citations_spec.rb
+++ b/spec/controllers/admin_controller/admin_controller_citations_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe AdminController, type: :controller do
+
   describe 'GET #citations' do
     context 'when admin is logged in' do
       before do
@@ -24,9 +25,9 @@ RSpec.describe AdminController, type: :controller do
         allow(controller).to receive(:session).and_return(admin: false)
       end
 
-      it 'redirects to publications_path' do
+      it 'redirects to  root path' do
         get :citations
-        expect(response).to redirect_to(publications_path)
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/controllers/admin_controller/admin_controller_citations_spec.rb
+++ b/spec/controllers/admin_controller/admin_controller_citations_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe AdminController, type: :controller do
-
   describe 'GET #citations' do
     context 'when admin is logged in' do
       before do

--- a/spec/controllers/admin_controller/admin_controller_csv_spec.rb
+++ b/spec/controllers/admin_controller/admin_controller_csv_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AdminController, type: :controller do
         it 'redirects with a notice' do
           get(:csv, params: common_params.merge({ format: 'csv' }), session: admin_session)
           expect(response).to redirect_to('/publications')
-          expect(flash[:notice]).to eq('Something went wrong while generating the CSV.')
+          expect(flash[:danger]).to eq('Something went wrong while generating the CSV.')
         end
       end
     end

--- a/spec/controllers/admin_controller/admin_controller_csv_spec.rb
+++ b/spec/controllers/admin_controller/admin_controller_csv_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe AdminController, type: :controller do
     end
 
     context 'when the user is not an admin' do
-      it 'redirects even if a valid format is provided' do
+      it 'redirects to the root page even if a valid format is provided' do
         get(:csv, params: common_params.merge({ format: 'csv' }))
-        expect(response).to redirect_to('/publications')
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/controllers/admin_controller/admin_controller_toggle_links_spec.rb
+++ b/spec/controllers/admin_controller/admin_controller_toggle_links_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe AdminController, type: :controller do
     context 'when session[:links] is true' do
       before do
         session[:links] = true
+        session[:admin] = true
       end
 
       it 'toggles session[:links] to false' do
@@ -23,6 +24,7 @@ RSpec.describe AdminController, type: :controller do
     context 'when session[:links] is false' do
       before do
         session[:links] = false
+        session[:admin] = true
       end
 
       it 'toggles session[:links] to true' do

--- a/spec/controllers/artworks_controller_spec.rb
+++ b/spec/controllers/artworks_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe ArtworksController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'location' => '', 'date' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/book_chapters_controller_spec.rb
+++ b/spec/controllers/book_chapters_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe BookChaptersController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'publisher' => '', 'page_numbers' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe BooksController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/colleges_controller_spec.rb
+++ b/spec/controllers/colleges_controller_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe CollegesController, type: :controller do
   # This should return the minimal set of values that should be in the session
   # in order to pass any filters (e.g. authentication) defined in
   # CollegesController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     it 'returns a success response' do

--- a/spec/controllers/concerns/cache_header_control_spec.rb
+++ b/spec/controllers/concerns/cache_header_control_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe CacheHeaderControl, type: :controller do
 
     it 'sets Cache-Control header' do
       get :index
-      puts response.headers
       expect(response.headers['Cache-Control']).to eq('no-cache')
     end
 

--- a/spec/controllers/concerns/cache_header_control_spec.rb
+++ b/spec/controllers/concerns/cache_header_control_spec.rb
@@ -1,0 +1,36 @@
+# spec/controllers/concerns/cache_header_control_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe CacheHeaderControl, type: :controller do
+  # Create a dummy controller that includes the concern
+  controller(ApplicationController) do
+    include CacheHeaderControl
+
+    def index
+      render plain: 'ok'
+    end
+  end
+
+  describe 'Cache headers' do
+    before do
+      routes.draw { get 'index', to: 'anonymous#index' }
+    end
+
+    it 'sets Cache-Control header' do
+      get :index
+      puts response.headers
+      expect(response.headers['Cache-Control']).to eq('no-cache, no-store, max-age=0, must-revalidate')
+    end
+
+    # it 'sets Pragma header' do
+    #   get :index
+    #   expect(response.headers['Pragma']).to eq('no-cache')
+    # end
+
+    # it 'sets Expires header' do
+    #   get :index
+    #   expect(response.headers['Expires']).to eq('Fri, 01 Jan 1990 00:00:00 GMT')
+    # end
+  end
+end

--- a/spec/controllers/concerns/cache_header_control_spec.rb
+++ b/spec/controllers/concerns/cache_header_control_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # spec/controllers/concerns/cache_header_control_spec.rb
 
 require 'rails_helper'
@@ -15,22 +17,23 @@ RSpec.describe CacheHeaderControl, type: :controller do
   describe 'Cache headers' do
     before do
       routes.draw { get 'index', to: 'anonymous#index' }
+      response.headers['Cache-Control'] = nil
     end
 
     it 'sets Cache-Control header' do
       get :index
       puts response.headers
-      expect(response.headers['Cache-Control']).to eq('no-cache, no-store, max-age=0, must-revalidate')
+      expect(response.headers['Cache-Control']).to eq('no-cache')
     end
 
-    # it 'sets Pragma header' do
-    #   get :index
-    #   expect(response.headers['Pragma']).to eq('no-cache')
-    # end
+    it 'sets Pragma header' do
+      get :index
+      expect(response.headers['Pragma']).to eq('no-cache')
+    end
 
-    # it 'sets Expires header' do
-    #   get :index
-    #   expect(response.headers['Expires']).to eq('Fri, 01 Jan 1990 00:00:00 GMT')
-    # end
+    it 'sets Expires header' do
+      get :index
+      expect(response.headers['Expires']).to eq('Fri, 01 Jan 1990 00:00:00 GMT')
+    end
   end
 end

--- a/spec/controllers/concerns/user_authentication_spec.rb
+++ b/spec/controllers/concerns/user_authentication_spec.rb
@@ -44,4 +44,19 @@ RSpec.describe UserAuthentication, type: :controller do
       end
     end
   end
+
+  describe 'handle_invalid_token' do
+    it 'resets the session and redirects to the login path' do
+      routes.draw { get 'index' => 'anonymous#index' }
+
+      # Simulate InvalidAuthenticityToken exception
+      expect(controller).to receive(:index).and_raise(ActionController::InvalidAuthenticityToken)
+
+      session[:admin] = true
+      get :index
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq('Your session has expired. Please log in again.')
+    end
+  end
 end

--- a/spec/controllers/concerns/user_authentication_spec.rb
+++ b/spec/controllers/concerns/user_authentication_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe UserAuthentication, type: :controller do
       it 'redirects to the root path with an alert' do
         get :index
         expect(response).to redirect_to(root_path)
-        expect(flash[:alert]).to eq('You must submit your information first.')
+        expect(flash[:danger]).to eq('You must submit your information first.')
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.describe UserAuthentication, type: :controller do
 
     context 'when submitter is logged in' do
       it 'does not redirect and allows access' do
-        submitter = FactoryBot.create(:submitter) # Replace with however you create a Submitter in your tests
+        submitter = FactoryBot.create(:submitter)
         session[:submitter_id] = submitter.id
         get :index
         expect(response).to have_http_status(:ok)
@@ -56,7 +56,7 @@ RSpec.describe UserAuthentication, type: :controller do
       get :index
 
       expect(response).to redirect_to(root_path)
-      expect(flash[:alert]).to eq('Your session has expired. Please log in again.')
+      expect(flash[:danger]).to eq('Your session has expired. Please log in again.')
     end
   end
 end

--- a/spec/controllers/concerns/user_authentication_spec.rb
+++ b/spec/controllers/concerns/user_authentication_spec.rb
@@ -1,0 +1,45 @@
+# spec/controllers/concerns/user_authentication_spec.rb
+
+require 'rails_helper'
+
+RSpec.describe UserAuthentication, type: :controller do
+  # Create a dummy controller that includes the concern
+  controller(ApplicationController) do
+    include UserAuthentication
+
+    def index
+      render plain: 'ok'
+    end
+  end
+
+  describe 'Authentication' do
+    before do
+      routes.draw { get 'index', to: 'anonymous#index' }
+    end
+
+    context 'when no user is authenticated' do
+      it 'redirects to the root path with an alert' do
+        get :index
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('You must submit your information first.')
+      end
+    end
+
+    context 'when admin is logged in' do
+      it 'does not redirect and allows access' do
+        session[:admin] = true
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when submitter is logged in' do
+      it 'does not redirect and allows access' do
+        submitter = FactoryBot.create(:submitter) # Replace with however you create a Submitter in your tests
+        session[:submitter_id] = submitter.id
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/user_authentication_spec.rb
+++ b/spec/controllers/concerns/user_authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # spec/controllers/concerns/user_authentication_spec.rb
 
 require 'rails_helper'

--- a/spec/controllers/digital_projects_controller_spec.rb
+++ b/spec/controllers/digital_projects_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe DigitalProjectsController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'name_of_site' => '', 'name_of_affiliated_organization' => '', 'publication_date' => '', 'version' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/editings_controller_spec.rb
+++ b/spec/controllers/editings_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe EditingsController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'volume' => '', 'issue' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -5,17 +5,35 @@
 require 'rails_helper'
 
 RSpec.describe ErrorsController, type: :controller do
-  describe 'GET #not_found' do
-    before do
-      get :not_found
-    end
-    it 'renders the not_found template' do
-      expect(response).to render_template('errors/404')
-      expect(response).to render_template('layouts/application')
-    end
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
+  let(:invalid_session) { { submitter_id: nil } }
 
-    it 'returns HTTP status 404' do
-      expect(response).to have_http_status(404)
+  # get :show, params: { id: submitter.to_param }, session: valid_session
+  context 'when a user is logged in' do
+    describe 'GET #not_found' do
+      before do
+        get :not_found, session: valid_session
+      end
+      it 'renders the not_found template' do
+        expect(response).to render_template('errors/404')
+        expect(response).to render_template('layouts/application')
+      end
+
+      it 'returns HTTP status 404' do
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+  context 'when a user is not logged in' do
+    describe 'GET #not_found' do
+      before do
+        get :not_found, session: invalid_session
+      end
+      it 'redirects to the root page' do
+        expect(response).to redirect_to(root_path)
+        expect(response).to have_http_status(302)
+      end
     end
   end
 end

--- a/spec/controllers/films_controller_spec.rb
+++ b/spec/controllers/films_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe FilmsController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'director' => '', 'release_year' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/journal_articles_controller_spec.rb
+++ b/spec/controllers/journal_articles_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe JournalArticlesController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'volume' => '', 'issue' => '', 'page_numbers' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/musical_scores_controller_spec.rb
+++ b/spec/controllers/musical_scores_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe MusicalScoresController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/other_publications_controller_spec.rb
+++ b/spec/controllers/other_publications_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe OtherPublicationsController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'volume' => '', 'issue' => '', 'page_numbers' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -3,12 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe PagesController, type: :controller do
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
+
   describe 'GET #show' do
     render_views
 
     context 'when page is valid' do
       it 'renders the page' do
-        get :show, params: { page: 'closed' }
+        get :show, params: { page: 'closed' }, session: valid_session
         expect(response).to render_template('pages/closed')
         expect(response.body).to have_text('The deadline for submissions has passed')
       end
@@ -16,12 +19,12 @@ RSpec.describe PagesController, type: :controller do
 
     context 'when page is invalid' do
       it 'returns a 404 status' do
-        get :show, params: { page: 'bad' }
+        get :show, params: { page: 'bad' }, session: valid_session
         expect(response.status).to eq(404)
       end
 
       it 'renders the 404 template' do
-        get :show, params: { page: 'bad' }
+        get :show, params: { page: 'bad' }, session: valid_session
         expect(response).to render_template('errors/404')
       end
     end

--- a/spec/controllers/photographies_controller_spec.rb
+++ b/spec/controllers/photographies_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe PhotographiesController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/physical_media_controller_spec.rb
+++ b/spec/controllers/physical_media_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe PhysicalMediaController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/plays_controller_spec.rb
+++ b/spec/controllers/plays_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe PlaysController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/public_performances_controller_spec.rb
+++ b/spec/controllers/public_performances_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe PublicPerformancesController, type: :controller do
     { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'location' => '', 'date' => '', 'time' => '' }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/publications_controller_spec.rb
+++ b/spec/controllers/publications_controller_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe PublicationsController, type: :controller do
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do

--- a/spec/controllers/submitters_controller_spec.rb
+++ b/spec/controllers/submitters_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe SubmittersController, type: :controller do
 
   let(:submitter) { FactoryBot.create(:submitter) }
   let(:valid_session) { { submitter_id: submitter.id } }
+  let(:old_session) { { submitter_id: 'alpha' } }
   let(:invalid_session) { { submitter_id: nil } }
 
   describe 'GET #show' do
@@ -49,6 +50,12 @@ RSpec.describe SubmittersController, type: :controller do
       it 'redirects to the publications show page' do
         post :create, params: { submitter: valid_attributes }, session: valid_session
         expect(response).to redirect_to(publications_path)
+      end
+
+      it 'resets session after successful creation' do
+        post :create, params: { submitter: valid_attributes }, session: old_session
+        expect(session['alpha']).to be_nil
+        expect(session[:submitter_id]).to eq(Submitter.last.id)
       end
     end
 

--- a/spec/controllers/submitters_controller_spec.rb
+++ b/spec/controllers/submitters_controller_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe SubmittersController, type: :controller do
     { first_name: '', last_name: '', college: 1, department: 'Application Development', mailing_address: '', phone_number: '', email_address: 'bad_email' }
   end
 
-  let(:valid_session) { {} }
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
+  let(:invalid_session) { { submitter_id: nil } }
 
   describe 'GET #show' do
     it 'returns a success response' do
@@ -40,7 +42,7 @@ RSpec.describe SubmittersController, type: :controller do
     context 'with valid params' do
       it 'creates a new Submitter' do
         expect do
-          post :create, params: { submitter: valid_attributes }, session: valid_session
+          post :create, params: { submitter: valid_attributes }, session: invalid_session
         end.to change(Submitter, :count).by(1)
       end
 
@@ -105,7 +107,7 @@ RSpec.describe SubmittersController, type: :controller do
 
     context 'when a manager is not logged in' do
       it 'redirects to finished page when finished' do
-        get :finished, session: { admin: nil }
+        get :finished, session: valid_session
         expect(response.body).to have_text('Your submission(s) was received')
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
-
   describe '#shorten_long' do
     it 'shortens a long string' do
       expect(shorten_long('thisisaverylongstringwithmorecharacters')).to eq('thisisaverylongs... ')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,21 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
-  describe '#signed_in' do
-    it 'returns true if admin is signed in' do
-      session[:admin] = true
-      expect(signed_in).to eq(true)
-    end
-
-    it 'returns submitter_id if submitter is signed in' do
-      session[:submitter_id] = 5
-      expect(signed_in).to eq(5)
-    end
-
-    it 'returns nil if no one is signed in' do
-      expect(signed_in).to be_nil
-    end
-  end
 
   describe '#shorten_long' do
     it 'shortens a long string' do

--- a/spec/requests/submitters_request_spec.rb
+++ b/spec/requests/submitters_request_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Submitters', type: :request do
+  describe 'GET /finished' do
+    it 'redirects to root with a flash warning if not logged in' do
+      get finished_path
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(flash[:danger]).to eq('You must submit your information first.')
+    end
+  end
+end

--- a/spec/routing/digital_projects_routing_spec.rb
+++ b/spec/routing/digital_projects_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe DigitalProjectsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/digital_projects').to route_to('digital_projects#index')

--- a/spec/routing/dynamic_pages_routing_spec.rb
+++ b/spec/routing/dynamic_pages_routing_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe PagesController, type: :routing do
       expect(get: '/pages/faq').to route_to('pages#show', page: 'faq')
     end
 
+    it 'routes to #closed' do
+      expect(get: '/pages/closed').to route_to('pages#show', page: 'closed')
+    end
+
     it 'does not route to #show without a page parameter' do
       expect(get: '/pages/').not_to be_routable
     end

--- a/spec/routing/films_routing_spec.rb
+++ b/spec/routing/films_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe FilmsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/films').to route_to('films#index')

--- a/spec/routing/musical_scores_routing_spec.rb
+++ b/spec/routing/musical_scores_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe MusicalScoresController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/musical_scores').to route_to('musical_scores#index')

--- a/spec/routing/physical_media_routing_spec.rb
+++ b/spec/routing/physical_media_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe PhysicalMediaController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/physical_media').to route_to('physical_media#index')

--- a/spec/routing/plays_routing_spec.rb
+++ b/spec/routing/plays_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe PlaysController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/plays').to route_to('plays#index')

--- a/spec/routing/public_performances_routing_spec.rb
+++ b/spec/routing/public_performances_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe PublicPerformancesController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/public_performances').to route_to('public_performances#index')


### PR DESCRIPTION
This PR addresses the fact that a user can just type in their address bar: libapps.libraries.uc.edu/aaec/publications and see the publications page even if they're not logged in as a submitter or admin user.  It does this by:

- Creating a new module, UserAuthentication to check if the user is signed in as a submitter or admin
  - Runs a before_action of :require_authenticated_user
     - redirects the user back to the root page (for creating a new submitter) if the user is neither logged in as a submitter nor an admin.
 - Created a new module, CacheHeaderControl, that should prevent the caching of pages.  This also Fixes Issue #249 Issue by requiring the sign-in pages to reload.
    - Rus a before_action of :set_cache_headers.
    - attempts to stop the usage of caching when using navigation arrows to return to pages after logging out.  This is not working for the Publications page, but appears to be working for all other pages.

- Appling UserAuthentication to error pages so users will not see an error page unless they're logged in.  If they go to a page that would normally give an error, they will be redirected to the submitter creation (root) page.  Signed-in users will see error pages like normal.  

- Not applying UserAuthentication to the controller functions needed to log in:
  - AdminController #login, #validate
  - SubmittersController #new, #create
- Updating tests to account for stricter user authentication requirements

Also included 
- Corrected the controller names for six routing tests that were using the incorrect name.  Fixing the name makes it so the correct context is pulled in.

- Added reset_session to Submitter#create to prevent session fixation attacks (security fix)