### PR TITLE
fixed routing test controller names

### DIFF
--- a/spec/routing/digital_projects_routing_spec.rb
+++ b/spec/routing/digital_projects_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe DigitalProjectsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/digital_projects').to route_to('digital_projects#index')

--- a/spec/routing/films_routing_spec.rb
+++ b/spec/routing/films_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe FilmsController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/films').to route_to('films#index')

--- a/spec/routing/musical_scores_routing_spec.rb
+++ b/spec/routing/musical_scores_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe MusicalScoresController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/musical_scores').to route_to('musical_scores#index')

--- a/spec/routing/physical_media_routing_spec.rb
+++ b/spec/routing/physical_media_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe PhysicalMediaController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/physical_media').to route_to('physical_media#index')

--- a/spec/routing/plays_routing_spec.rb
+++ b/spec/routing/plays_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe PlaysController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/plays').to route_to('plays#index')

--- a/spec/routing/public_performances_routing_spec.rb
+++ b/spec/routing/public_performances_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BookChaptersController, type: :routing do
+RSpec.describe PublicPerformancesController, type: :routing do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/public_performances').to route_to('public_performances#index')


### PR DESCRIPTION
Fixes #258 

There were a half dozen tests in the routing tests that had incorrect controller names.  I updated the controller names to reflect the controller routings we meant to be testing.