### PR TITLE
279 - Create custom validation for author first and last names

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,5 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  include AuthorNameValidations
 end

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -2,12 +2,11 @@
 
 class Artwork < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department location date]

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,12 +2,11 @@
 
 class Book < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department publisher city publication_date url doi]

--- a/app/models/book_chapter.rb
+++ b/app/models/book_chapter.rb
@@ -2,12 +2,11 @@
 
 class BookChapter < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department publisher city publication_date url doi page_numbers]

--- a/app/models/concerns/author_name_validations.rb
+++ b/app/models/concerns/author_name_validations.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# CustomValidations is a Rails concern that enhances ActiveRecord models with
+# additional validation methods. These methods address edge cases not handled
+# by built-in ActiveRecord validations.
+#
+# This module extends ActiveSupport::Concern, making it straightforward
+# to include in any ActiveRecord model. It is included in the parent class
+# ApplicationRecord, so all models that inherit from ApplicationRecord
+# will have access to these methods.
+#
+# One key use-case for CustomValidations is to more rigorously validate presence.
+# For instance, an array like [''] would pass the standard `validates_presence_of`
+# check, but may not be considered valid according to business rules.
+#
+# @example Usage in an ActiveRecord model
+#   class OtherPublication < ApplicationRecord
+#
+#     validate :validate_author_names
+
+#   end
+module AuthorNameValidations
+  extend ActiveSupport::Concern
+
+  def validate_author_names
+    validate_name_not_empty(:author_first_name)
+    validate_name_not_empty(:author_last_name)
+    validate_names_length
+  end
+
+  private
+
+  def validate_name_not_empty(attribute)
+    return if send(attribute).present? && send(attribute).none?(&:blank?)
+
+    errors.add(attribute, "can't be empty or contain blank entries")
+  end
+
+  def validate_names_length
+    return if author_first_name&.length == author_last_name&.length
+
+    errors.add(:base, 'Both first and last names are required and must have the same number of entries')
+  end
+end

--- a/app/models/digital_project.rb
+++ b/app/models/digital_project.rb
@@ -2,12 +2,11 @@
 
 class DigitalProject < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department name_of_site name_of_affiliated_organization publication_date version url doi]

--- a/app/models/editing.rb
+++ b/app/models/editing.rb
@@ -2,12 +2,11 @@
 
 class Editing < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department volume issue publisher city publication_date url doi]

--- a/app/models/film.rb
+++ b/app/models/film.rb
@@ -2,12 +2,11 @@
 
 class Film < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department producer director release_year]

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -2,12 +2,11 @@
 
 class JournalArticle < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department volume issue page_numbers publication_date url doi]

--- a/app/models/musical_score.rb
+++ b/app/models/musical_score.rb
@@ -2,12 +2,11 @@
 
 class MusicalScore < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department publisher city publication_date url doi]

--- a/app/models/other_publication.rb
+++ b/app/models/other_publication.rb
@@ -2,12 +2,11 @@
 
 class OtherPublication < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department volume issue page_numbers publisher city publication_date url doi]

--- a/app/models/photography.rb
+++ b/app/models/photography.rb
@@ -2,12 +2,11 @@
 
 class Photography < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department publisher city publication_date url doi]

--- a/app/models/physical_medium.rb
+++ b/app/models/physical_medium.rb
@@ -2,12 +2,11 @@
 
 class PhysicalMedium < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department publisher city publication_date url doi]

--- a/app/models/play.rb
+++ b/app/models/play.rb
@@ -2,12 +2,11 @@
 
 class Play < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department publisher city publication_date url doi]

--- a/app/models/public_performance.rb
+++ b/app/models/public_performance.rb
@@ -2,12 +2,11 @@
 
 class PublicPerformance < ApplicationRecord
   include Csv
+  has_and_belongs_to_many :colleges
+  validates :work_title, presence: true
+  validate :validate_author_names
   serialize :author_first_name, Array
   serialize :author_last_name, Array
-  has_and_belongs_to_many :colleges
-  validates :author_first_name, presence: true
-  validates :author_last_name, presence: true
-  validates :work_title, presence: true
 
   def self.to_csv
     attributes = %w[submitter_id work_title other_title authors colleges uc_department location time date]

--- a/spec/features/create_admin_spec.rb
+++ b/spec/features/create_admin_spec.rb
@@ -4,8 +4,11 @@ require 'rails_helper'
 
 describe 'Create Admin', :feature, js: true do
   before do
-    20.times do
+    # Sometimes the testing database already has 2 submitters created.
+    (20 - Submitter.count).times do
       FactoryBot.create(:submitter)
+    end
+    20.times do
       FactoryBot.create(:book)
       FactoryBot.create(:other_publication)
       FactoryBot.create(:journal_article)

--- a/spec/features/create_admin_spec.rb
+++ b/spec/features/create_admin_spec.rb
@@ -4,11 +4,8 @@ require 'rails_helper'
 
 describe 'Create Admin', :feature, js: true do
   before do
-    # Sometimes the testing database already has 2 submitters created.
-    (20 - Submitter.count).times do
-      FactoryBot.create(:submitter)
-    end
     20.times do
+      FactoryBot.create(:submitter)
       FactoryBot.create(:book)
       FactoryBot.create(:other_publication)
       FactoryBot.create(:journal_article)

--- a/spec/models/concerns/author_name_validations_spec.rb
+++ b/spec/models/concerns/author_name_validations_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Book, type: :model do
+  let(:book) { Book.new(work_title: 'Default Title') }
+
+  describe 'validations' do
+    context 'when author names are empty or contain blank entries' do
+      it 'is not valid with empty first names' do
+        book.author_first_name = []
+        book.author_last_name = ['Doe']
+        expect(book).not_to be_valid
+        expect(book.errors[:author_first_name]).to include("can't be empty or contain blank entries")
+      end
+
+      it 'is not valid with blank first names' do
+        book.author_first_name = ['']
+        book.author_last_name = ['Doe']
+        expect(book).not_to be_valid
+        expect(book.errors[:author_first_name]).to include("can't be empty or contain blank entries")
+      end
+
+      it 'is not valid with empty last names' do
+        book.author_first_name = ['John']
+        book.author_last_name = []
+        expect(book).not_to be_valid
+        expect(book.errors[:author_last_name]).to include("can't be empty or contain blank entries")
+      end
+
+      it 'is not valid with blank last names' do
+        book.author_first_name = ['John']
+        book.author_last_name = ['']
+        expect(book).not_to be_valid
+        expect(book.errors[:author_last_name]).to include("can't be empty or contain blank entries")
+      end
+    end
+
+    context 'when author names arrays are of unequal length' do
+      it 'is not valid if first and last names have different number of entries' do
+        book.author_first_name = %w[John Jane]
+        book.author_last_name = ['Doe']
+        expect(book).not_to be_valid
+        expect(book.errors[:base]).to include('Both first and last names are required and must have the same number of entries')
+      end
+    end
+
+    # Additional context for valid cases
+    context 'when author names are valid' do
+      it 'is valid with equal number of first and last names' do
+        book.author_first_name = %w[John Jane]
+        book.author_last_name = %w[Doe Doe]
+        expect(book).to be_valid
+      end
+
+      it 'is valid with one author' do
+        book.author_first_name = ['John']
+        book.author_last_name = ['Doe']
+        expect(book).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/concerns/author_name_validations_spec.rb
+++ b/spec/models/concerns/author_name_validations_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe Book, type: :model do
       end
     end
 
+    context 'when author names are nil' do
+      it 'is not valid with nil first names' do
+        book.author_first_name = nil
+        book.author_last_name = ['Doe']
+        expect(book).not_to be_valid
+        expect(book.errors[:author_first_name]).to include("can't be empty or contain blank entries")
+      end
+
+      it 'is not valid with nil last names' do
+        book.author_first_name = ['John']
+        book.author_last_name = nil
+        expect(book).not_to be_valid
+        expect(book.errors[:author_last_name]).to include("can't be empty or contain blank entries")
+      end
+    end
+
     context 'when author names arrays are of unequal length' do
       it 'is not valid if first and last names have different number of entries' do
         book.author_first_name = %w[John Jane]


### PR DESCRIPTION
Fixes #279

## **Create custom validation for author first and last names to avoid empty arrays and empty strings in arrays.**

### Why this is needed
Even though author first and last names of publication types are stored as strings in the database, they are converted to arrays upon loading by 
```
serialize :author_first_name, Array
serialize :author_last_name, Array
```
Likewise, when they are being added during creation of a publication type, they are added as an array of first and an array of last names.

What I mean is this.  If I were to create a new book with these authors:
![Screenshot 2023-11-15 at 2 47 49 PM](https://github.com/uclibs/aaec/assets/57018862/9d6f5fe2-167b-4d7f-84fb-2023df199ccd)
We would be working with author_first_name of ['John', 'Jane'] and author_last_name of ['Doe', 'Merriweather']

The original validation of these fields was simply 
```
validates :author_first_name, presence: true
validates :author_last_name, presence: true
```
,which does not prevent data like [""] and ["",""] from being saved.

### Changes made:

- Created a new app/models/concerns/author_name_validations.rb file which prevents the saving of blank or nil values.
- Added AuthorNameValidations to ApplicationRecord so that it would be inherited by all models
- invoked validate :validate_author_names on each publication type that had author names
- arranged has_and_belongs_to_many, validations, and serializations in Ruby-standard order