### PR TITLE
281 Enhance Security by Implementing reset_session in SubmittersController

### DIFF
--- a/app/controllers/submitters_controller.rb
+++ b/app/controllers/submitters_controller.rb
@@ -22,6 +22,7 @@ class SubmittersController < ApplicationController
 
     respond_to do |format|
       if @submitter.save
+        reset_session
         session[:submitter_id] = @submitter.id
         # Change to home page
         flash.keep[:success] = 'Your account was successfully created.'

--- a/spec/controllers/submitters_controller_spec.rb
+++ b/spec/controllers/submitters_controller_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe SubmittersController, type: :controller do
     { first_name: '', last_name: '', college: 1, department: 'Application Development', mailing_address: '', phone_number: '', email_address: 'bad_email' }
   end
 
-  let(:valid_session) { {} }
+  let(:old_submitter) { FactoryBot.create(:submitter) }
+  let(:old_session) { { submitter_id: old_submitter.id } }
+
+  let(:submitter) { FactoryBot.create(:submitter) }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #show' do
     it 'returns a success response' do
@@ -38,14 +42,21 @@ RSpec.describe SubmittersController, type: :controller do
 
   describe 'POST #create' do
     context 'with valid params' do
+      it 'clears the old session' do
+        post :create, params: { submitter: valid_attributes }, session: old_session
+        expect(session[:submitter_id]).not_to be_nil
+        expect(session[:submitter_id]).not_to eq(old_session[:submitter_id])
+        expect(session[:submitter_id]).to eq(Submitter.last.id)
+      end
+
       it 'creates a new Submitter' do
         expect do
-          post :create, params: { submitter: valid_attributes }, session: valid_session
+          post :create, params: { submitter: valid_attributes }, session: {}
         end.to change(Submitter, :count).by(1)
       end
 
       it 'redirects to the publications show page' do
-        post :create, params: { submitter: valid_attributes }, session: valid_session
+        post :create, params: { submitter: valid_attributes }, session: {}
         expect(response).to redirect_to(publications_path)
       end
     end


### PR DESCRIPTION
Fixes #281 

### Description
This PR introduces a crucial security enhancement to our SubmittersController by implementing the reset_session method. This change is designed to mitigate session fixation attacks, a type of security vulnerability where an attacker can potentially hijack a user's session.

### Changes Made
Incorporated reset_session in the create action of the SubmittersController.
This change ensures that a new session is started every time a submitter account is created, invalidating any previously existing session identifiers.
### Implementation Details
The reset_session method is called immediately before we set the new submitter_id in the session after successfully creating a new submitter.
This effectively clears any existing session data and establishes a new, clean session.
### Testing
Added RSpec tests to verify that the old session is cleared and a new session is established with a new submitter_id after the creation of a new submitter.
### Impact
This change adds an extra layer of security for our users and protects the integrity of their sessions, especially during the account creation process.
There are no expected impacts on performance or existing functionalities.
