### PR TITLE
287 - Correct rerouting after destroy for PublicationsController

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -153,7 +153,7 @@ class PublicationsController < ApplicationController
     instance_variable.destroy
     respond_to do |format|
       flash.keep[:warning] = "#{controller_name.classify} was successfully destroyed."
-      format.html { redirect_to instance_variable }
+      format.html { redirect_to publications_path }
       format.json { head :no_content }
     end
   end

--- a/spec/controllers/artworks_controller_spec.rb
+++ b/spec/controllers/artworks_controller_spec.rb
@@ -93,9 +93,10 @@ RSpec.describe ArtworksController, type: :controller do
       end.to change(Artwork, :count).by(-1)
     end
 
-    it 'redirects to the artworks list' do
+    it 'redirects to the publications_path' do
+      artwork = Artwork.create! valid_attributes
       delete :destroy, params: { id: artwork.to_param }, session: valid_session
-      expect(response).to redirect_to(artworks_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/book_chapters_controller_spec.rb
+++ b/spec/controllers/book_chapters_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe BookChaptersController, type: :controller do
       end.to change(BookChapter, :count).by(-1)
     end
 
-    it 'redirects to the book_chapters list' do
+    it 'redirects to the publications_path' do
+      book_chapter = BookChapter.create! valid_attributes
       delete :destroy, params: { id: book_chapter.to_param }, session: valid_session
-      expect(response).to redirect_to(book_chapters_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/books_controller_spec.rb
+++ b/spec/controllers/books_controller_spec.rb
@@ -96,9 +96,10 @@ RSpec.describe BooksController, type: :controller do
       end.to change(Book, :count).by(-1)
     end
 
-    it 'redirects to the books list' do
+    it 'redirects to the publications_path' do
+      book = Book.create! valid_attributes
       delete :destroy, params: { id: book.to_param }, session: valid_session
-      expect(response).to redirect_to(books_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/digital_projects_controller_spec.rb
+++ b/spec/controllers/digital_projects_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe DigitalProjectsController, type: :controller do
       end.to change(DigitalProject, :count).by(-1)
     end
 
-    it 'redirects to the digital_projects list' do
+    it 'redirects to the publications path' do
+      digital_project = DigitalProject.create! valid_attributes
       delete :destroy, params: { id: digital_project.to_param }, session: valid_session
-      expect(response).to redirect_to(digital_projects_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/editings_controller_spec.rb
+++ b/spec/controllers/editings_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe EditingsController, type: :controller do
       end.to change(Editing, :count).by(-1)
     end
 
-    it 'redirects to the editings list' do
+    it 'redirects to the publications_path' do
+      editing = Editing.create! valid_attributes
       delete :destroy, params: { id: editing.to_param }, session: valid_session
-      expect(response).to redirect_to(editings_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/films_controller_spec.rb
+++ b/spec/controllers/films_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe FilmsController, type: :controller do
       end.to change(Film, :count).by(-1)
     end
 
-    it 'redirects to the films list' do
+    it 'redirects to the publications_path' do
+      film = Film.create! valid_attributes
       delete :destroy, params: { id: film.to_param }, session: valid_session
-      expect(response).to redirect_to(films_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/journal_articles_controller_spec.rb
+++ b/spec/controllers/journal_articles_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe JournalArticlesController, type: :controller do
       end.to change(JournalArticle, :count).by(-1)
     end
 
-    it 'redirects to the journal_articles list' do
+    it 'redirects to the publications_path' do
+      journal_article = JournalArticle.create! valid_attributes
       delete :destroy, params: { id: journal_article.to_param }, session: valid_session
-      expect(response).to redirect_to(journal_articles_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/musical_scores_controller_spec.rb
+++ b/spec/controllers/musical_scores_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe MusicalScoresController, type: :controller do
       end.to change(MusicalScore, :count).by(-1)
     end
 
-    it 'redirects to the musical_scores list' do
+    it 'redirects to the publications_path' do
+      musical_score = MusicalScore.create! valid_attributes
       delete :destroy, params: { id: musical_score.to_param }, session: valid_session
-      expect(response).to redirect_to(musical_scores_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/other_publications_controller_spec.rb
+++ b/spec/controllers/other_publications_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe OtherPublicationsController, type: :controller do
       end.to change(OtherPublication, :count).by(-1)
     end
 
-    it 'redirects to the other_publications list' do
+    it 'redirects to the publications_path' do
+      other_publication = OtherPublication.create! valid_attributes
       delete :destroy, params: { id: other_publication.to_param }, session: valid_session
-      expect(response).to redirect_to(other_publications_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/photographies_controller_spec.rb
+++ b/spec/controllers/photographies_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe PhotographiesController, type: :controller do
       end.to change(Photography, :count).by(-1)
     end
 
-    it 'redirects to the photographys list' do
+    it 'redirects to the publications_path' do
+      photography = Photography.create! valid_attributes
       delete :destroy, params: { id: photography.to_param }, session: valid_session
-      expect(response).to redirect_to(photographies_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/physical_media_controller_spec.rb
+++ b/spec/controllers/physical_media_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe PhysicalMediaController, type: :controller do
       end.to change(PhysicalMedium, :count).by(-1)
     end
 
-    it 'redirects to the physical_mediums list' do
+    it 'redirects to the publications_path' do
+      physical_medium = PhysicalMedium.create! valid_attributes
       delete :destroy, params: { id: physical_medium.to_param }, session: valid_session
-      expect(response).to redirect_to(physical_media_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/plays_controller_spec.rb
+++ b/spec/controllers/plays_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe PlaysController, type: :controller do
       end.to change(Play, :count).by(-1)
     end
 
-    it 'redirects to the plays list' do
+    it 'redirects to the publications page' do
+      play = Play.create! valid_attributes
       delete :destroy, params: { id: play.to_param }, session: valid_session
-      expect(response).to redirect_to(plays_url)
+      expect(response).to redirect_to(publications_url)
     end
   end
 end

--- a/spec/controllers/public_performances_controller_spec.rb
+++ b/spec/controllers/public_performances_controller_spec.rb
@@ -97,9 +97,10 @@ RSpec.describe PublicPerformancesController, type: :controller do
       end.to change(PublicPerformance, :count).by(-1)
     end
 
-    it 'redirects to the public_performances list' do
+    it 'redirects to the publications_path' do
+      public_performance = PublicPerformance.create! valid_attributes
       delete :destroy, params: { id: public_performance.to_param }, session: valid_session
-      expect(response).to redirect_to(public_performances_url)
+      expect(response).to redirect_to(publications_path)
     end
   end
 end

--- a/spec/controllers/public_performances_controller_spec.rb
+++ b/spec/controllers/public_performances_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PublicPerformancesController, type: :controller do
 
   let(:submitter) { FactoryBot.create(:submitter) }
   let(:valid_session) { { submitter_id: submitter.id } }
-  let(:public_performance) { PublicPerformance.create! valid_attributes }
+  let(:public_performance) { FactoryBot.create(:public_performance, submitter_id: submitter.id) }
 
   it_behaves_like 'restricts non-logged-in users', {
     'index' => :get,
@@ -93,13 +93,12 @@ RSpec.describe PublicPerformancesController, type: :controller do
 
     it 'destroys the requested public_performance' do
       expect do
-        delete :destroy, params: { id: public_performance.to_param }, session: valid_session
+        delete :destroy, params: { id: public_performance.id }, session: valid_session
       end.to change(PublicPerformance, :count).by(-1)
     end
 
     it 'redirects to the publications_path' do
-      public_performance = PublicPerformance.create! valid_attributes
-      delete :destroy, params: { id: public_performance.to_param }, session: valid_session
+      delete :destroy, params: { id: public_performance.id }, session: valid_session
       expect(response).to redirect_to(publications_path)
     end
   end

--- a/spec/support/shared_examples/allowed_access.rb
+++ b/spec/support/shared_examples/allowed_access.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples 'allowed access' do |action, method, user_role|
       instance_var = instance_variable_get("@#{controller.controller_name.singularize}")
       expect(response).to redirect_to(instance_var)
     when 'destroy'
-      expect(response).to redirect_to(index_url_for(controller.controller_name))
+      expect(response).to redirect_to(publications_url)
     when 'new', 'edit', 'show'
       expect(response).to be_successful
     when 'index'


### PR DESCRIPTION
Fixes #287 

The publications_controller #destroy method was redirecting back to "instance_variable", which in every case was then redirecting the user to the publications path.  This PR changes the destroy method so that it routes back to the publications path directly, removing the extra rerouting.  It also updates the tests to reflect that change.