### PR TITLE
289 - Change :new to :edit upon failed update for PublicationsController

### DIFF
--- a/spec/controllers/colleges_controller_spec.rb
+++ b/spec/controllers/colleges_controller_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe CollegesController, type: :controller do
       it "returns a success response (i.e. to display the 'edit' template)" do
         put :update, params: { id: college.to_param, college: invalid_attributes }, session: valid_session
         expect(response).to be_successful
+        expect(response).to render_template(:edit)
       end
     end
   end

--- a/spec/controllers/submitters_controller_spec.rb
+++ b/spec/controllers/submitters_controller_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe SubmittersController, type: :controller do
         submitter = Submitter.create! valid_attributes
         put :update, params: { id: submitter.to_param, submitter: invalid_attributes }, session: valid_session
         expect(response).to be_successful
+        expect(response).to render_template(:edit)
       end
     end
   end


### PR DESCRIPTION
Fixes #289 

When an update to the publication fails, it will now correctly redirect the user back to the :edit page rather than the :new page.  This is in line with standard Ruby practices and would have been the expected redirection.

This bug hadn't been caught before because we didn't check what page was rendered, only that there was a "success" response.  I've added this check to our publication-type update tests.