### PR TITLE
295 - Move code to toggle college 'other' field to own file

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require popper
 //= require bootstrap-sprockets
 //= require bootstrap-tooltip-initialization
+//= require toggle_college_other_field
 
 function addAuthor(type, count)    {
     var count = count || 1;
@@ -44,33 +45,3 @@ function addAuthor(type, count)    {
 function removeAuthor(idToDelete)     {
     document.getElementById(idToDelete).outerHTML = '';
 }
-
-$(document).on('turbolinks:load', function() {
-    if (window.location.pathname.includes("/edit") || window.location.pathname.includes("/new")) {
-        otherChkbox = document.querySelector('[id$="_college_ids_16"]');
-        otherField = document.querySelector('[id$="_other_college"]');
-        otherGroup = document.querySelector('[id$="other_college_group"]');
-        tempStorage = '';
-
-        if (otherField.value != "") {
-            otherChkbox.checked = true;
-        }
-        else    {
-            otherGroup.classList.toggle("d-none");
-        }
-
-        otherChkbox.onclick = function() {
-            if (otherChkbox.checked) {
-                otherGroup.classList.toggle("d-none");
-                    if (tempStorage != '') {
-                        otherField.value = tempStorage;
-                    }
-                }
-            else    {
-                otherGroup.classList.toggle("d-none");
-                tempStorage = otherField.value;
-                otherField.value = '';
-            } 
-        }
-    }
-})

--- a/app/assets/javascripts/toggle_college_other_field.js
+++ b/app/assets/javascripts/toggle_college_other_field.js
@@ -1,0 +1,29 @@
+$(document).on('turbolinks:load', function() {
+  if (window.location.pathname.includes("/edit") || window.location.pathname.includes("/new")) {
+      otherChkbox = document.querySelector('[id$="_college_ids_16"]');
+      otherField = document.querySelector('[id$="_other_college"]');
+      otherGroup = document.querySelector('[id$="other_college_group"]');
+      tempStorage = '';
+
+      if (otherField.value != "") {
+          otherChkbox.checked = true;
+      }
+      else    {
+          otherGroup.classList.toggle("d-none");
+      }
+
+      otherChkbox.onclick = function() {
+          if (otherChkbox.checked) {
+              otherGroup.classList.toggle("d-none");
+                  if (tempStorage != '') {
+                      otherField.value = tempStorage;
+                  }
+              }
+          else    {
+              otherGroup.classList.toggle("d-none");
+              tempStorage = otherField.value;
+              otherField.value = '';
+          } 
+      }
+  }
+})


### PR DESCRIPTION
Fixes #295 

This PR moves the code to toggle the showing/hiding of the college's "other" field over into its own file and then imports it into app/assets/javascripts/application.js.

No functional change is expected.