### PR TITLE
304 - Refactor _author partial for clarity

### DIFF
--- a/app/views/partials/_author.html.erb
+++ b/app/views/partials/_author.html.erb
@@ -1,28 +1,26 @@
-<%= form_with(model: publication) do |form| %>
-    <div id="author_group">
-      <% if publication.author_first_name.empty? && publication.author_last_name.empty? %>
-        <% publication.author_first_name << '' %>
-        <% publication.author_last_name << '' %>
-      <% end %>
-  
-      <% publication.author_first_name.each_with_index do |_, index| %>
-        <div class="form-row" id="author_<%= index %>">
-          <div class="col-md-5">
-            <%= label_tag "publication_author_first_name_#{index}", "Author First Name", class: "required" %>
-            <%= text_field_tag "publication[author_first_name][]", publication.author_first_name[index], required: true, class: "form-control form-group" %>
-          </div>
-          <div class="col-md-5">
-            <%= label_tag "publication_author_last_name_#{index}", "Author Last Name", class: "required" %>
-            <%= text_field_tag "publication[author_last_name][]", publication.author_last_name[index], required: true, class: "form-control form-group" %>
-          </div>
-          <% if index > 0 %>
-            <div class="col-md-2">
-              <%= button_tag "Remove Author", type: "button", onclick: "removeAuthor('author_#{index}')", class: "form-control form-group bg-danger text-white" %>
-            </div>
-          <% end %>
+
+<div id="author_group">
+    <% if publication.author_first_name.empty? && publication.author_last_name.empty? %>
+    <% publication.author_first_name << '' %>
+    <% publication.author_last_name << '' %>
+    <% end %>
+
+    <% publication.author_first_name.each_with_index do |_, index| %>
+    <div class="form-row" id="author_<%= index %>">
+        <div class="col-md-5">
+        <%= label_tag "#{name}_author_first_name_#{index}", "Author First Name", class: "required" %>
+        <%= text_field_tag "#{name}[author_first_name][]", publication.author_first_name[index], required: true, class: "form-control form-group" %>
         </div>
-      <% end %>
+        <div class="col-md-5">
+        <%= label_tag "#{name}_author_last_name_#{index}", "Author Last Name", class: "required" %>
+        <%= text_field_tag "#{name}[author_last_name][]", publication.author_last_name[index], required: true, class: "form-control form-group" %>
+        </div>
+        <% if index > 0 %>
+        <div class="col-md-2">
+            <%= button_tag "Remove Author", type: "button", onclick: "removeAuthor('author_#{index}')", class: "form-control form-group bg-danger text-white" %>
+        </div>
+        <% end %>
     </div>
-    <%= button_tag "Add Author", type: "button", id: "add_author_btn", onclick: "addAuthor()", class: "btn btn-primary" %>
-  <% end %>
-  
+    <% end %>
+</div>
+<%= button_tag "Add Author", type: "button", id: "add_author_btn", onclick: "addAuthor()", class: "btn btn-primary" %>

--- a/app/views/partials/_author.html.erb
+++ b/app/views/partials/_author.html.erb
@@ -8,8 +8,8 @@
     <% publication.author_first_name.each_with_index do |_, index| %>
     <div class="form-row" id="author_<%= index %>">
         <div class="col-md-5">
-        <%= label_tag "#{name}_author_first_name_#{index}", "Author First Name", class: "required" %>
-        <%= text_field_tag "#{name}[author_first_name][]", publication.author_first_name[index], required: true, class: "form-control form-group" %>
+            <%= label_tag(:author_first_name, author_or_artist_label + ' First Name', class: "required") %>
+            <%= text_field_tag "#{name}[author_first_name][]", publication.author_first_name[index], required: true, class: "form-control form-group" %>
         </div>
         <div class="col-md-5">
         <%= label_tag "#{name}_author_last_name_#{index}", "Author Last Name", class: "required" %>
@@ -23,4 +23,4 @@
     </div>
     <% end %>
 </div>
-<%= button_tag "Add Author", type: "button", id: "add_author_btn", onclick: "addAuthor()", class: "btn btn-primary" %>
+<%= button_tag "Add Author", type: "button", id: "add_author_btn", onclick: "addAuthor('#{name}')", class: "btn btn-primary" %>

--- a/app/views/partials/_author.html.erb
+++ b/app/views/partials/_author.html.erb
@@ -1,44 +1,28 @@
-<%# Take in the name, and publication object %>
-<span id="author_group">
-    <div class="form-row">
-            <div class="col-md-5">
-                <%= label_tag(:author_first_name, author_or_artist_label + ' First Name', class: "required") %>
-            </div>
-            <div class="col-md-5">
-                <%= label_tag(:author_last_name, author_or_artist_label + ' Last Name', class: "required") %>
-            </div>
+<%= form_with(model: publication) do |form| %>
+    <div id="author_group">
+      <% if publication.author_first_name.empty? && publication.author_last_name.empty? %>
+        <% publication.author_first_name << '' %>
+        <% publication.author_last_name << '' %>
+      <% end %>
+  
+      <% publication.author_first_name.each_with_index do |_, index| %>
+        <div class="form-row" id="author_<%= index %>">
+          <div class="col-md-5">
+            <%= label_tag "publication_author_first_name_#{index}", "Author First Name", class: "required" %>
+            <%= text_field_tag "publication[author_first_name][]", publication.author_first_name[index], required: true, class: "form-control form-group" %>
+          </div>
+          <div class="col-md-5">
+            <%= label_tag "publication_author_last_name_#{index}", "Author Last Name", class: "required" %>
+            <%= text_field_tag "publication[author_last_name][]", publication.author_last_name[index], required: true, class: "form-control form-group" %>
+          </div>
+          <% if index > 0 %>
             <div class="col-md-2">
-                <!-- Empty for Delete button -->
+              <%= button_tag "Remove Author", type: "button", onclick: "removeAuthor('author_#{index}')", class: "form-control form-group bg-danger text-white" %>
             </div>
+          <% end %>
+        </div>
+      <% end %>
     </div>
-    <% (0..publication.author_first_name.count-1).to_a.each do | count | %>
-        <div class="form-row" id="<%= "author_" + count.to_s %>" >
-            <div class="col-md-5">
-                <%= text_field_tag "#{name}[author_first_name][]", publication.author_first_name[count], required: true, class: "form-control form-group" %>
-            </div>
-            <div class="col-md-5">
-                <%= text_field_tag "#{name}[author_last_name][]", publication.author_last_name[count], required: true, class: "form-control form-group" %>
-            </div>
-            <div class="col-md-2">
-                <%= button_tag "Remove Author", type: "button", onclick: "removeAuthor('author_#{count}');", class: "form-control form-group bg-danger text-white" %>
-            </div>
-        </div>
-    <% end %>
-
-    <% if publication.author_first_name.count == 0 %>
-
-        <div class="form-row" id="author_0">
-            <div class="col-md-5">
-                <%= text_field_tag "#{name}[author_first_name][]", nil, required: true, class: "form-control form-group" %>
-            </div>
-            <div class="col-md-5">
-                <%= text_field_tag "#{name}[author_last_name][]", nil, required: true, class: "form-control form-group" %>
-            </div>
-            <div class="col-md-2">
-                <%= button_tag "Remove Author", type: "button", onclick: "removeAuthor('author_0');", id: "first_author", class: "form-control form-group bg-danger text-white invisible" %>
-            </div>
-        </div>
-
-    <% end %>
-</span>
-<%= button_tag "Add Author", type: "button", id: "add_author_btn", onclick: "addAuthor('#{name}');", class: "btn btn-primary" %>
+    <%= button_tag "Add Author", type: "button", id: "add_author_btn", onclick: "addAuthor()", class: "btn btn-primary" %>
+  <% end %>
+  

--- a/spec/controllers/other_publications_controller_spec.rb
+++ b/spec/controllers/other_publications_controller_spec.rb
@@ -3,18 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe OtherPublicationsController, type: :controller do
-
-  let!(:submitter) { FactoryBot.create(:submitter) }
-
   let(:valid_attributes) do
-    { 'author_first_name' => %w[Test Person], 'author_last_name' => %w[Case 2], 'college_ids' => ['', '1', '4'], 'uc_department' => 'Test', 'work_title' => 'Test', 'other_title' => 'Test', 'volume' => 'Test', 'issue' => 'Test', 'page_numbers' => 'Test', 'publisher' => 'Test', 'city' => 'Test', 'publication_date' => 'Test', 'url' => 'Test', 'doi' => 'Test', 'submitter_id' => submitter.id }
+    { 'author_first_name' => %w[Test Person], 'author_last_name' => %w[Case 2], 'college_ids' => ['', '1', '4'], 'uc_department' => 'Test', 'work_title' => 'Test', 'other_title' => 'Test', 'volume' => 'Test', 'issue' => 'Test', 'page_numbers' => 'Test', 'publisher' => 'Test', 'city' => 'Test', 'publication_date' => 'Test', 'url' => 'Test', 'doi' => 'Test' }
   end
 
   let(:invalid_attributes) do
-    { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'volume' => '', 'issue' => '', 'page_numbers' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '', 'submitter_id' => submitter.id }
+    { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'volume' => '', 'issue' => '', 'page_numbers' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
   end
 
-  let(:valid_session) { { submitter_id: submitter.id } }
+  let(:valid_session) { { submitter_id: 1 } }
 
   describe 'GET #index' do
     before do
@@ -38,9 +35,10 @@ RSpec.describe OtherPublicationsController, type: :controller do
 
   describe 'GET #show as admin' do
     it 'returns a success response' do
+      FactoryBot.create(:submitter)
       session[:admin] = true
       other_publication = OtherPublication.create! valid_attributes
-      get :show, params: { id: other_publication.to_param }
+      get :show, params: { id: other_publication.to_param }, session: valid_session
       expect(response).to be_successful
     end
   end
@@ -62,6 +60,9 @@ RSpec.describe OtherPublicationsController, type: :controller do
 
   describe 'POST #create' do
     context 'with valid params' do
+      before do
+        FactoryBot.create(:submitter)
+      end
 
       it 'creates a new Other Publication' do
         expect do

--- a/spec/controllers/other_publications_controller_spec.rb
+++ b/spec/controllers/other_publications_controller_spec.rb
@@ -3,15 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe OtherPublicationsController, type: :controller do
+
+  let!(:submitter) { FactoryBot.create(:submitter) }
+
   let(:valid_attributes) do
-    { 'author_first_name' => %w[Test Person], 'author_last_name' => %w[Case 2], 'college_ids' => ['', '1', '4'], 'uc_department' => 'Test', 'work_title' => 'Test', 'other_title' => 'Test', 'volume' => 'Test', 'issue' => 'Test', 'page_numbers' => 'Test', 'publisher' => 'Test', 'city' => 'Test', 'publication_date' => 'Test', 'url' => 'Test', 'doi' => 'Test' }
+    { 'author_first_name' => %w[Test Person], 'author_last_name' => %w[Case 2], 'college_ids' => ['', '1', '4'], 'uc_department' => 'Test', 'work_title' => 'Test', 'other_title' => 'Test', 'volume' => 'Test', 'issue' => 'Test', 'page_numbers' => 'Test', 'publisher' => 'Test', 'city' => 'Test', 'publication_date' => 'Test', 'url' => 'Test', 'doi' => 'Test', 'submitter_id' => submitter.id }
   end
 
   let(:invalid_attributes) do
-    { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'volume' => '', 'issue' => '', 'page_numbers' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '' }
+    { 'author_first_name' => ['Bad'], 'author_last_name' => [''], 'college_ids' => [''], 'uc_department' => '', 'work_title' => '', 'other_title' => '', 'volume' => '', 'issue' => '', 'page_numbers' => '', 'publisher' => '', 'city' => '', 'publication_date' => '', 'url' => '', 'doi' => '', 'submitter_id' => submitter.id }
   end
 
-  let(:valid_session) { { submitter_id: 1 } }
+  let(:valid_session) { { submitter_id: submitter.id } }
 
   describe 'GET #index' do
     before do
@@ -35,10 +38,9 @@ RSpec.describe OtherPublicationsController, type: :controller do
 
   describe 'GET #show as admin' do
     it 'returns a success response' do
-      FactoryBot.create(:submitter)
       session[:admin] = true
       other_publication = OtherPublication.create! valid_attributes
-      get :show, params: { id: other_publication.to_param }, session: valid_session
+      get :show, params: { id: other_publication.to_param }
       expect(response).to be_successful
     end
   end
@@ -60,9 +62,6 @@ RSpec.describe OtherPublicationsController, type: :controller do
 
   describe 'POST #create' do
     context 'with valid params' do
-      before do
-        FactoryBot.create(:submitter)
-      end
 
       it 'creates a new Other Publication' do
         expect do


### PR DESCRIPTION
Fixes #304 

This PR refactors the _authors partial at app/views/partials/_author.html.erb for clarity.  It does not change the calls to the JavaScript functions to add or delete authors.  There is one visible change from the original version.  The original version had a blank space after the first author because it includes an invisible "remove" button.  The refactored version does not include the blank button.

The layout issues will be addressed with issue #305.

Refactored code:
(Included to make it easier to read)
```

<div id="author_group">
    <% if publication.author_first_name.empty? && publication.author_last_name.empty? %>
    <% publication.author_first_name << '' %>
    <% publication.author_last_name << '' %>
    <% end %>

    <% publication.author_first_name.each_with_index do |_, index| %>
    <div class="form-row" id="author_<%= index %>">
        <div class="col-md-5">
            <%= label_tag(:author_first_name, author_or_artist_label + ' First Name', class: "required") %>
            <%= text_field_tag "#{name}[author_first_name][]", publication.author_first_name[index], required: true, class: "form-control form-group" %>
        </div>
        <div class="col-md-5">
        <%= label_tag "#{name}_author_last_name_#{index}", "Author Last Name", class: "required" %>
        <%= text_field_tag "#{name}[author_last_name][]", publication.author_last_name[index], required: true, class: "form-control form-group" %>
        </div>
        <% if index > 0 %>
        <div class="col-md-2">
            <%= button_tag "Remove Author", type: "button", onclick: "removeAuthor('author_#{index}')", class: "form-control form-group bg-danger text-white" %>
        </div>
        <% end %>
    </div>
    <% end %>
</div>
<%= button_tag "Add Author", type: "button", id: "add_author_btn", onclick: "addAuthor('#{name}')", class: "btn btn-primary" %>
```




