### PR TITLE
296 - Refactor show/hide 'other' college field

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,4 +20,3 @@
 //= require add_remove_authors
 //= require toggle_college_other_field
 //= require_tree .
-

--- a/app/assets/javascripts/toggle_college_other_field.js
+++ b/app/assets/javascripts/toggle_college_other_field.js
@@ -1,29 +1,34 @@
+// Show or hide the other college text field based on the checkbox
+// The field is hidden by default, and the checkbox is checked if the field has a value
+// If the checkbox is unchecked, the field's value is stored in tempStorage and the field is cleared
 $(document).on('turbolinks:load', function() {
-  if (window.location.pathname.includes("/edit") || window.location.pathname.includes("/new")) {
-      otherChkbox = document.querySelector('[id$="_college_ids_16"]');
-      otherField = document.querySelector('[id$="_other_college"]');
-      otherGroup = document.querySelector('[id$="other_college_group"]');
-      tempStorage = '';
+    if (window.location.pathname.includes("/edit") || window.location.pathname.includes("/new")) {
+        setupOtherCollegeCheckbox();
+    }
+});
 
-      if (otherField.value != "") {
-          otherChkbox.checked = true;
-      }
-      else    {
-          otherGroup.classList.toggle("d-none");
-      }
+function setupOtherCollegeCheckbox() {
+    const otherChkbox = document.querySelector('[id$="_college_ids_16"]');
+    const otherField = document.querySelector('[id$="_other_college"]');
+    const otherGroup = document.querySelector('[id$="other_college_group"]');
 
-      otherChkbox.onclick = function() {
-          if (otherChkbox.checked) {
-              otherGroup.classList.toggle("d-none");
-                  if (tempStorage != '') {
-                      otherField.value = tempStorage;
-                  }
-              }
-          else    {
-              otherGroup.classList.toggle("d-none");
-              tempStorage = otherField.value;
-              otherField.value = '';
-          } 
-      }
-  }
-})
+    // Initialize or use existing tempStorage
+    otherField.tempStorage = otherField.tempStorage || '';
+
+    // Set initial state based on otherField's value
+    otherChkbox.checked = otherField.value !== "";
+    otherGroup.classList.toggle("d-none", !otherChkbox.checked);
+
+    // Event listener for the checkbox
+    otherChkbox.addEventListener('click', () => {
+        otherGroup.classList.toggle("d-none");
+        if (otherChkbox.checked) {
+            if (otherField.tempStorage !== '') {
+                otherField.value = otherField.tempStorage;
+            }
+        } else {
+            otherField.tempStorage = otherField.value;
+            otherField.value = '';
+        }
+    });
+}

--- a/app/views/artworks/_form.html.erb
+++ b/app/views/artworks/_form.html.erb
@@ -10,47 +10,33 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "artwork", publication: @artwork} %>
-
   <hr>
+
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
   <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
       </div>
-
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :date, 'Date of Composition' %>
-          <%= form.text_field :date, class: "form-control" %>
-        </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :date, 'Date of Composition' %>
+        <%= form.text_field :date, class: "form-control" %>
       </div>
     </div>
+  </div>
 
-  <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
-  </div>  
-
-<%= hidden_field_tag "artwork[submitter_id]", session[:submitter_id] || @artwork.submitter_id %>
+  <%= hidden_field_tag "artwork[submitter_id]", session[:submitter_id] || @artwork.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/book_chapters/_form.html.erb
+++ b/app/views/book_chapters/_form.html.erb
@@ -10,48 +10,37 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "book_chapter", publication: @book_chapter} %>
-
   <hr>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "UC College") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :publisher %>
-          <%= form.text_field :publisher, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :city %>
-          <%= form.text_field :city, class: "form-control" %>
-        </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :publisher %>
+        <%= form.text_field :publisher, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :city %>
+        <%= form.text_field :city, class: "form-control" %>
       </div>
     </div>
+  </div>
 
   <div class="form-row">
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>  
     <div class="form-group col-md-6">
       <%= form.label :publication_date, 'Publication Date' %>
       <%= form.text_field :publication_date, class: "form-control" %>
@@ -76,7 +65,7 @@
     </div>
   </div>
 
-<%= hidden_field_tag "book_chapter[submitter_id]", session[:submitter_id] || @book_chapter.submitter_id %>
+  <%= hidden_field_tag "book_chapter[submitter_id]", session[:submitter_id] || @book_chapter.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -10,49 +10,37 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "book", publication: @book} %>
-
   <hr>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
 
-      <div class="col-md-6">
-        
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :publisher %>
-          <%= form.text_field :publisher, class: "form-control" %>
-        </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :publisher %>
+        <%= form.text_field :publisher, class: "form-control" %>
+      </div>
        <div class="form-group">
         <%= form.label :city %>
         <%= form.text_field :city, class: "form-control" %>
       </div>
-      </div>
     </div>
+  </div>
 
-  <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
+  <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label :publication_date, 'Publication Date' %>
       <%= form.text_field :publication_date, class: "form-control" %>
@@ -70,7 +58,7 @@
     </div>
   </div>
 
-<%= hidden_field_tag "book[submitter_id]", session[:submitter_id] || @book.submitter_id %>
+  <%= hidden_field_tag "book[submitter_id]", session[:submitter_id] || @book.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/colleges/_form.html.erb
+++ b/app/views/colleges/_form.html.erb
@@ -4,9 +4,10 @@
       <h4 class="alert-heading"><%= pluralize(college.errors.count, "error") %> found:</h4>
       <hr>
       <ul>
-      <% college.errors.full_messages.each do |message| %>
-        <p class="mb-0"><%= message %></p>
-      <% end %>
+        <% college.errors.full_messages.each do |message| %>
+          <p class="mb-0"><%= message %></p>
+        <% end %>
+      </ul>
     </div>
   <% end %>
 

--- a/app/views/digital_projects/_form.html.erb
+++ b/app/views/digital_projects/_form.html.erb
@@ -10,48 +10,37 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "digital_project", publication: @digital_project} %>
-
   <hr>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :name_of_site, 'Name of Site' %>
-          <%= form.text_field :name_of_site, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :name_of_affiliated_organization, 'Name of Affiliated Organization' %>
-          <%= form.text_field :name_of_affiliated_organization, class: "form-control" %>
-        </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :name_of_site, 'Name of Site' %>
+        <%= form.text_field :name_of_site, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :name_of_affiliated_organization, 'Name of Affiliated Organization' %>
+        <%= form.text_field :name_of_affiliated_organization, class: "form-control" %>
       </div>
     </div>
+  </div>
 
   <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
     <div class="form-group col-md-6">
       <%= form.label :version %>
       <%= form.text_field :version, class: "form-control" %>
@@ -77,7 +66,7 @@
     </div>
   </div>
 
-<%= hidden_field_tag "digital_project[submitter_id]", session[:submitter_id] || @digital_project.submitter_id %>
+  <%= hidden_field_tag "digital_project[submitter_id]", session[:submitter_id] || @digital_project.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/editings/_form.html.erb
+++ b/app/views/editings/_form.html.erb
@@ -10,49 +10,38 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "editing", publication: @editing} %>
-
   <hr>
 
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :volume %>
-          <%= form.text_field :volume, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :issue %>
-          <%= form.text_field :issue, class: "form-control" %>
-        </div>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :volume %>
+        <%= form.text_field :volume, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :issue %>
+        <%= form.text_field :issue, class: "form-control" %>
       </div>
     </div>
+  </div>
 
   <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
     <div class="form-group col-md-6">
       <%= form.label :city %>
       <%= form.text_field :city, class: "form-control" %>
@@ -79,7 +68,7 @@
       <%= form.text_field :doi, class: "form-control" %>
     </div>
   </div>
-  <%# Note: This may need to be changed since it will always use the logged in submitters id %>
+
   <%= hidden_field_tag "editing[submitter_id]", session[:submitter_id] || @editing.submitter_id %>
 
   <div class="actions">

--- a/app/views/films/_form.html.erb
+++ b/app/views/films/_form.html.erb
@@ -10,55 +10,44 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "film", publication: @film} %>
-
   <hr>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :director %>
-          <%= form.text_field :director, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :producer %>
-          <%= form.text_field :producer, class: "form-control" %>
-        </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :director %>
+        <%= form.text_field :director, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :producer %>
+        <%= form.text_field :producer, class: "form-control" %>
       </div>
     </div>
+  </div>
     
-  <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
+  <div class="form-row">
     <div class="form-group">
           <%= form.label :release_year, 'Release Year' %>
           <%= form.text_field :release_year, class: "form-control" %>
     </div>
   </div>  
 
-<%= hidden_field_tag "film[submitter_id]", session[:submitter_id] || @film.submitter_id %>
+  <%= hidden_field_tag "film[submitter_id]", session[:submitter_id] || @film.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/journal_articles/_form.html.erb
+++ b/app/views/journal_articles/_form.html.erb
@@ -12,46 +12,36 @@
   <%= render partial: "partials/author", locals: {name: "journal_article", publication: @journal_article} %>
   <hr>
 
+
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
   <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
       </div>
-
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :volume %>
-          <%= form.text_field :volume, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :issue %>
-          <%= form.text_field :issue, class: "form-control" %>
-        </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :volume %>
+        <%= form.text_field :volume, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :issue %>
+        <%= form.text_field :issue, class: "form-control" %>
       </div>
     </div>
+  </div>
 
-  <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
+  <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label :page_numbers, 'Page Numbers' %>
       <%= form.text_field :page_numbers, class: "form-control" %>
@@ -74,7 +64,7 @@
       <%= form.text_field :doi, class: "form-control" %>
     </div>
   </div>
-  <%# Note: This may need to be changed since it will always use the logged in submitters id %>
+
   <%= hidden_field_tag "journal_article[submitter_id]", session[:submitter_id] || @journal_article.submitter_id %>
 
   <div class="actions">

--- a/app/views/musical_scores/_form.html.erb
+++ b/app/views/musical_scores/_form.html.erb
@@ -10,48 +10,37 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "musical_score", publication: @musical_score} %>
-
   <hr>
+
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
   <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
       </div>
-
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :publisher %>
-          <%= form.text_field :publisher, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :city %>
-          <%= form.text_field :city, class: "form-control" %>
-        </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :publisher %>
+        <%= form.text_field :publisher, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :city %>
+        <%= form.text_field :city, class: "form-control" %>
       </div>
     </div>
+  </div>
 
-  <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
+  <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label :publication_date, 'Publication Date' %>
       <%= form.text_field :publication_date, class: "form-control" %>
@@ -69,7 +58,7 @@
     </div>
   </div>
 
-<%= hidden_field_tag "musical_score[submitter_id]", session[:submitter_id] || @musical_score.submitter_id %>
+  <%= hidden_field_tag "musical_score[submitter_id]", session[:submitter_id] || @musical_score.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/other_publications/_form.html.erb
+++ b/app/views/other_publications/_form.html.erb
@@ -10,54 +10,42 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "other_publication", publication: @other_publication} %>
-
   <hr>
 
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :volume %>
-          <%= form.text_field :volume, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :issue %>
-          <%= form.text_field :issue, class: "form-control" %>
-        </div>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :volume %>
+        <%= form.text_field :volume, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :issue %>
+        <%= form.text_field :issue, class: "form-control" %>
       </div>
     </div>
+  </div>
+
   <div class="form-row">
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
     <div class="form-group col-md-6">
       <%= form.label :page_numbers, 'Page Numbers' %>
       <%= form.text_field :page_numbers, class: "form-control" %>
     </div>
-
-    
   </div>
 
   <div class="form-row">
@@ -81,14 +69,14 @@
       <%= form.text_field :url, class: "form-control" %>
     </div>
   </div>
-  <div class="form-row">
 
+  <div class="form-row">
     <div class="form-group col-md-6">
       <%= form.label :doi, 'DOI (Digital Object Identifier)' %>
       <%= form.text_field :doi, class: "form-control" %>
     </div>
   </div>
-  <%# Note: This may need to be changed since it will always use the logged in submitters id %>
+
   <%= hidden_field_tag "other_publication[submitter_id]", session[:submitter_id] || @other_publication.submitter_id %>
 
   <div class="actions">

--- a/app/views/partials/_publications_colleges.html.erb
+++ b/app/views/partials/_publications_colleges.html.erb
@@ -1,0 +1,16 @@
+<div class="form-group col-md-6">
+  <%= form.label(:college_ids, author_or_artist_label + " College(s)") %><br />
+  <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
+    <div class="form-check">
+      <%= c.check_box class: "form-check-input" %>
+      <%= c.label class: "form-check-label" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="form-row">
+  <div id="other_college_group" class="form-group col-md-6">
+    <%= form.label :other_college, 'Other College' %>
+    <%= form.text_field :other_college, class: "form-control" %>
+  </div>
+</div>

--- a/app/views/photographies/_form.html.erb
+++ b/app/views/photographies/_form.html.erb
@@ -11,46 +11,36 @@
 
   <%= render partial: "partials/author", locals: {name: "photography", publication: @photography} %>
   <hr>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "UC College") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :publisher %>
-          <%= form.text_field :publisher, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :city %>
-          <%= form.text_field :city, class: "form-control" %>
-        </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :publisher %>
+        <%= form.text_field :publisher, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :city %>
+        <%= form.text_field :city, class: "form-control" %>
       </div>
     </div>
+  </div>
 
   <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
     <div class="form-group col-md-6">
       <%= form.label :publication_date, 'Publication Date' %>
       <%= form.text_field :publication_date, class: "form-control" %>
@@ -68,7 +58,7 @@
     </div>
   </div>  
 
-<%= hidden_field_tag "photography[submitter_id]", session[:submitter_id] || @photography.submitter_id %>
+  <%= hidden_field_tag "photography[submitter_id]", session[:submitter_id] || @photography.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/physical_media/_form.html.erb
+++ b/app/views/physical_media/_form.html.erb
@@ -11,46 +11,36 @@
 
   <%= render partial: "partials/author", locals: {name: "physical_medium", publication: @physical_medium} %>
   <hr>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :publisher %>
-          <%= form.text_field :publisher, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :city %>
-          <%= form.text_field :city, class: "form-control" %>
-        </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :publisher %>
+        <%= form.text_field :publisher, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :city %>
+        <%= form.text_field :city, class: "form-control" %>
       </div>
     </div>
+  </div>
 
   <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
     <div class="form-group col-md-6">
       <%= form.label :publication_date, 'Publication Date' %>
       <%= form.text_field :publication_date, class: "form-control" %>
@@ -68,7 +58,7 @@
     </div>
   </div>
 
-<%= hidden_field_tag "physical_medium[submitter_id]", session[:submitter_id] || @physical_medium.submitter_id %>
+  <%= hidden_field_tag "physical_medium[submitter_id]", session[:submitter_id] || @physical_medium.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/plays/_form.html.erb
+++ b/app/views/plays/_form.html.erb
@@ -10,48 +10,37 @@
   <% end %>
 
   <%= render partial: "partials/author", locals: {name: "play", publication: @play} %>
-
   <hr>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
 
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :publisher %>
-          <%= form.text_field :publisher, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :city %>
-          <%= form.text_field :city, class: "form-control" %>
-        </div>
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :publisher %>
+        <%= form.text_field :publisher, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :city %>
+        <%= form.text_field :city, class: "form-control" %>
       </div>
     </div>
+  </div>
 
   <div class="form-row">  
-    <div id="other_college_group" class="form-group col-md-6">
-      <%= form.label :other_college, 'Other College' %>
-      <%= form.text_field :other_college, class: "form-control" %>
-    </div>
     <div class="form-group col-md-6">
       <%= form.label :publication_date, 'Publication Date' %>
       <%= form.text_field :publication_date, class: "form-control" %>
@@ -69,7 +58,7 @@
     </div>
   </div>
 
-<%= hidden_field_tag "play[submitter_id]", session[:submitter_id] || @play.submitter_id %>
+  <%= hidden_field_tag "play[submitter_id]", session[:submitter_id] || @play.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/public_performances/_form.html.erb
+++ b/app/views/public_performances/_form.html.erb
@@ -11,53 +11,43 @@
 
   <%= render partial: "partials/author", locals: {name: "public_performance", publication: @public_performance} %>
   <hr>
+
+  <%= render partial: "partials/publications_colleges", locals: {form: form} %>
+  <hr>
+
+  <div class="form-row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
+        <%= form.text_field :uc_department, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
+        <%= form.text_field :work_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :other_title, 'Other Title' %>
+        <%= form.text_field :other_title, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :location, 'Location (of showing/performance)' %>
+        <%= form.text_field :location, class: "form-control" %>
+      </div>
+      <div class="form-group">
+        <%= form.label :time %>
+        <%= form.text_field :time, class: "form-control" %>
+      </div>
+    </div>
+  </div>
+
   <div class="form-row">
     <div class="form-group col-md-6">
-      <%= form.label(:college_ids, "Author College(s)") %><br />
-      <%= form.collection_check_boxes :college_ids, College.all, :id, :name do |c| %>
-        <div class="form-check">
-          <%= c.check_box class: "form-check-input" %>
-          <%= c.label class: "form-check-label" %>
-        </div>
-      <% end %>
-      </div>
-
-      <div class="col-md-6">
-        <div class="form-group">
-          <%= form.label(:uc_department, "UC Department(s) or Division(s)") %>
-          <%= form.text_field :uc_department, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :work_title, 'Title of Submitted Work', class: "required" %>
-          <%= form.text_field :work_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :other_title, 'Other Title' %>
-          <%= form.text_field :other_title, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :location, 'Location (of showing/performance)' %>
-          <%= form.text_field :location, class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.label :time %>
-          <%= form.text_field :time, class: "form-control" %>
-        </div>
-      </div>
+      <%= form.label :date %>
+      <%= form.text_field :date, class: "form-control" %>
     </div>
+  </div>
 
-    <div class="form-row">  
-      <div id="other_college_group" class="form-group col-md-6">
-        <%= form.label :other_college, 'Other College' %>
-        <%= form.text_field :other_college, class: "form-control" %>
-      </div>
-      <div class="form-group col-md-6">
-        <%= form.label :date %>
-        <%= form.text_field :date, class: "form-control" %>
-      </div>
-    </div>
-
-<%= hidden_field_tag "public_performance[submitter_id]", session[:submitter_id] || @public_performance.submitter_id %>
+  <%= hidden_field_tag "public_performance[submitter_id]", session[:submitter_id] || @public_performance.submitter_id %>
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>


### PR DESCRIPTION
Fixes #296 

## Refactor of setupOtherCollegeCheckbox Function for Dynamic Form Interaction
### Overview
This pull request introduces a refactor of the setupOtherCollegeCheckbox function. The refactor enhances the interaction with the "Other College" checkbox and related text field in our forms, specifically on the edit and new pages. The changes improve the code's readability and functionality, ensuring a more intuitive user experience.

### Key Changes
#### Integration with Turbolinks:

The function is now explicitly executed only when the Turbolinks load event is triggered and on specific pages ("/edit" and "/new"). This ensures the code runs only in the relevant context, improving performance and preventing unnecessary executions.
#### Dynamic State Synchronization:

Implemented logic to check the "Other College" checkbox automatically if the corresponding text field has a pre-filled value. This is particularly useful in edit forms, ensuring that the state of the checkbox correctly reflects the existing data.
#### Visibility Control of the Text Field:

Adjusted the code to show or hide the "Other College" text field based on the state of the checkbox. This makes the form more dynamic and responsive to user input, improving the overall user experience.
#### Introduction of tempStorage for State Preservation:

Added a tempStorage property to the text field element to store its value temporarily. This allows for the text field's content to be preserved and restored if the checkbox is toggled, preventing data loss during user interaction.
#### Refined Event Handling:

Replaced inline event handling with a more robust event listener attached to the checkbox. This approach follows best practices for event handling in JavaScript and enhances maintainability.

#### Move repeated College fields and logic to its own partial
Each of the publication types' forms repeated the block of college selection and the "other" college field.  I took this PR as an opportunity to move this block into a partial to DRY the code up a bit and to make future maintenance easier.  It will also place the Other College selection field in a consistent place in each of the publication types.  
