### PR TITLE
263 - Modify College.find(:id) calls to account for destroyed colleges

### DIFF
--- a/app/controllers/colleges_controller.rb
+++ b/app/controllers/colleges_controller.rb
@@ -68,7 +68,7 @@ class CollegesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_college
-    @college = College.find(params[:id])
+    @college = College.find_by(id: params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/helpers/colleges_helper.rb
+++ b/app/helpers/colleges_helper.rb
@@ -22,11 +22,10 @@ module CollegesHelper
   end
 
   def college_name(id)
-    if id.nil?
-      ''
-    else
-      College.find(id).name
-    end
+    return '' if id.nil?
+
+    college = College.find_by(id:)
+    college&.name.to_s
   end
 
   def college_array(publication)

--- a/app/helpers/colleges_helper.rb
+++ b/app/helpers/colleges_helper.rb
@@ -22,10 +22,7 @@ module CollegesHelper
   end
 
   def college_name(id)
-    return '' if id.nil?
-
-    college = College.find_by(id:)
-    college&.name.to_s
+    College.name_for(id)
   end
 
   def college_array(publication)

--- a/app/models/college.rb
+++ b/app/models/college.rb
@@ -4,4 +4,11 @@ class College < ApplicationRecord
   has_and_belongs_to_many :books, dependent: :destroy
   has_and_belongs_to_many :other_publications, dependent: :destroy
   validates :name, presence: true
+
+  def self.name_for(id)
+    return '' if id.nil?
+
+    college = College.find_by(id:)
+    college&.name.to_s
+  end
 end

--- a/app/models/csv.rb
+++ b/app/models/csv.rb
@@ -20,10 +20,7 @@ module Csv
   end
 
   def college_name(id)
-    return '' if id.nil?
-
-    college = College.find_by(id:)
-    college&.name.to_s
+    College.name_for(id)
   end
 
   def colleges

--- a/app/models/csv.rb
+++ b/app/models/csv.rb
@@ -20,11 +20,10 @@ module Csv
   end
 
   def college_name(id)
-    if id.nil?
-      ''
-    else
-      College.find(id).name
-    end
+    return '' if id.nil?
+
+    college = College.find_by(id:)
+    college&.name.to_s
   end
 
   def colleges


### PR DESCRIPTION
Fixes #263 

Modify college_name(id) functions to account for destroyed colleges.

We were trying to do College.find(id), which would crash if we couldn't find a college with that id.  This refactoring of the college_name(id) function will return an empty string if either id is nil or if there is not a college with the sent id.