### PR TITLE
353 - Update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ SQLite 3
 
 ## Running the tests
 1. Run the database migrations: ```bundle exec rake db:migrate``` (Optional)
-1. Run the test suite: ```bundle exec rake spec```
+1. Run the test suite: ```bundle exec rspec```


### PR DESCRIPTION
Fixes #353 

Updates README.md instructions for testing to say to run `bundle exec rspec` instead of `bundle exec rake spec`.