### PR TITLE
360 - Fix flaky test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
 orbs:
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.0.2
-  browser-tools: circleci/browser-tools@1.3.0
+  browser-tools: circleci/browser-tools@latest
   coveralls: coveralls/coveralls@1.0.6
 
 jobs:
@@ -46,10 +46,7 @@ jobs:
       - checkout
       - node/install:
           node-version: "18.17.1"
-      # - browser-tools/install-chrome TODO: change the following 2 lines to this after fixing the orb issue #75.
-      - browser-tools/install-browser-tools:
-          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
 orbs:
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.0.2
-  browser-tools: circleci/browser-tools@latest
+  browser-tools: circleci/browser-tools@1.4.6
   coveralls: coveralls/coveralls@1.0.6
 
 jobs:


### PR DESCRIPTION
Fixes #360 
Allow circleci to use most recent version of Chromedriver

We were having problems with one specific feature test failing.  Chromedriver had been pinned at an earlier version due to a bug in the browser tools orb, but that's been fixed.  This PR allows circleci to again use the latest version of chromedriver and chrome to test the PR's.