### PR TITLE
Update browser-tools orb in CI config.yml to address chromedriver 404 error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,17 +46,9 @@ jobs:
       - checkout
       - node/install:
           node-version: "18.17.1"
-      - browser-tools/install-browser-tools
-      - run:
-          name: Install stable ChromeDriver version
-          command: |
-            CHROMEDRIVER_VERSION="121.0.6167.184"
-            sudo rm -f /usr/local/bin/chromedriver
-            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/115.0.5763.0/linux64/chromedriver-linux64.zip"
-            unzip /tmp/chromedriver.zip -d /tmp
-            sudo mv /tmp/chromedriver /usr/local/bin/chromedriver
-            sudo chmod +x /usr/local/bin/chromedriver
-            chromedriver --version
+      - browser-tools/install-browser-tools:
+          chrome-version: 121.0.6167.184
+            - browser-tools/install-chromedriver
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             CHROMEDRIVER_VERSION="121.0.6167.184"
             sudo rm -f /usr/local/bin/chromedriver
-            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.184/linux64/chrome-linux64.zip"
+            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.184/linux64/chromedriver-linux64.zip"
             unzip /tmp/chromedriver.zip -d /tmp
             sudo mv /tmp/chromedriver /usr/local/bin/chromedriver
             sudo chmod +x /usr/local/bin/chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,16 @@ jobs:
       - node/install:
           node-version: "18.17.1"
       - browser-tools/install-browser-tools
-
+      - run:
+          name: Install ChromeDriver version "122.0.6261.39"
+          command: |
+            CHROMEDRIVER_VERSION="122.0.6261.39"
+            sudo rm -f /usr/local/bin/chromedriver
+            wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+            unzip /tmp/chromedriver.zip -d /tmp
+            sudo mv /tmp/chromedriver /usr/local/bin/chromedriver
+            sudo chmod +x /usr/local/bin/chromedriver
+            chromedriver --version
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             CHROMEDRIVER_VERSION="121.0.6167.184"
             sudo rm -f /usr/local/bin/chromedriver
-            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.184/linux64/chromedriver-linux64.zip"
+            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/115.0.5763.0/linux64/chromedriver-linux64.zip"
             unzip /tmp/chromedriver.zip -d /tmp
             sudo mv /tmp/chromedriver /usr/local/bin/chromedriver
             sudo chmod +x /usr/local/bin/chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,11 @@ jobs:
           node-version: "18.17.1"
       - browser-tools/install-browser-tools
       - run:
-          name: Install ChromeDriver version "122.0.6261.39"
+          name: Install stable ChromeDriver version
           command: |
-            CHROMEDRIVER_VERSION="122.0.6261.39"
+            CHROMEDRIVER_VERSION="121.0.6167.184"
             sudo rm -f /usr/local/bin/chromedriver
-            wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/${CHROMEDRIVER_VERSION}/linux64/chrome-linux64.zip"
             unzip /tmp/chromedriver.zip -d /tmp
             sudo mv /tmp/chromedriver /usr/local/bin/chromedriver
             sudo chmod +x /usr/local/bin/chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: |
             CHROMEDRIVER_VERSION="121.0.6167.184"
             sudo rm -f /usr/local/bin/chromedriver
-            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/${CHROMEDRIVER_VERSION}/linux64/chrome-linux64.zip"
+            wget -O /tmp/chromedriver.zip "https://storage.googleapis.com/chrome-for-testing-public/121.0.6167.184/linux64/chrome-linux64.zip"
             unzip /tmp/chromedriver.zip -d /tmp
             sudo mv /tmp/chromedriver /usr/local/bin/chromedriver
             sudo chmod +x /usr/local/bin/chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
 orbs:
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.0.2
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.4.7
   coveralls: coveralls/coveralls@1.0.6
 
 jobs:
@@ -46,9 +46,8 @@ jobs:
       - checkout
       - node/install:
           node-version: "18.17.1"
-      - browser-tools/install-browser-tools:
-          chrome-version: 121.0.6167.184
-            - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools
+
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Fixes #373 

The URL for chromedriver was changed last week, causing 404 errors when attempting to download chromedriver tools for testing in CI.  This PR updates the web-tools orb which works with the new URLS.