### PR TITLE
247/adjust submitter login page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,11 @@
 
 /* Custom bootstrap variables must be set or imported *before* bootstrap. */
 @import "bootstrap";
+@import "forms";
+
+*, *::before, *::after {
+   box-sizing: border-box;
+}
 
 .required:after {
    content: " *";

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,0 +1,37 @@
+.two-column-form {
+  display: flex;
+  flex-direction: column;
+
+  input, select {
+    border: 1px solid #adb5bd; /* Default state */
+  }
+
+  input:focus, select:focus {
+    border-color: #6c757d; /* Darker border on focus */
+    outline: none; /* Removes the default focus outline to rely on the border change */
+  }
+
+
+  // Tablets and above need two columns, mobile needs one
+  @media (min-width: 768px) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .two-column-item {
+    flex: 1 1 auto;
+    margin: 10px;
+    @media (min-width: 768px) {
+      flex: 0 1 45%;
+    }
+  }
+
+  .add-padding-bottom {
+    padding-bottom: 1.5rem;
+  }
+}
+
+.two-column-left-button {
+  margin-left: 10px;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
     </nav>
     <div class="nav-sub-bar mb-2">
       <div class="container">
-        <%= link_to "LIBRARIES", "https://libraries.uc.edu/", target: "_blank", class: "text-white" %>
+        <%= link_to "LIBRARIES", "https://libraries.uc.edu/", target: "_blank", class: "text-white text-decoration-none" %>
       </div>
     </div>
     <div class="container offset-footer">

--- a/app/views/submitters/_form.html.erb
+++ b/app/views/submitters/_form.html.erb
@@ -9,51 +9,45 @@
     </div>
   <% end %>
 
-  <div class="form-row">
-    <div class="form-group col-md-6">
+  <div class="form-row two-column-form">
+    <div class="form-group two-column-item add-padding-bottom">
       <%= form.label :first_name, 'First Name', class: "required" %>
       <%= form.text_field :first_name, required: true, class: "form-control" %>
     </div>
 
-    <div class="form-group col-md-6">
+    <div class="form-group two-column-item add-padding-bottom">
       <%= form.label :last_name, 'Last Name', class: "required" %>
       <%= form.text_field :last_name, required: true, class: "form-control" %>
     </div>
-  </div>
 
-  <div class="form-row">
-    <div class="form-group col-md-6">
+    <div class="form-group two-column-item">
       <%= form.label(:college, "UC College") %>
       <%= select_tag "submitter[college]", options_from_collection_for_select(College.all, :id, :name, @submitter.college), prompt: "Please select a college", class: "form-control" %>
       <small class="form-text text-muted">If "Other", enter your college and department in the UC Department field</small>
     </div>
 
-    <div class="form-group col-md-6">
+    <div class="form-group two-column-item add-padding-bottom">
       <%= form.label(:department, "UC Department or Division") %>
       <%= form.text_field :department, class: "form-control" %>
     </div>
-  </div>
 
-  <div class="form-row">
-    <div class="form-group col-md-6">
+    <div class="form-group two-column-item add-padding-bottom">
       <%= form.label(:mailing_address, "Mail Location (Postal address if off campus)", class: "required") %>
       <%= form.text_field :mailing_address, required: true, class: "form-control" %>
     </div>
 
-    <div class="form-group col-md-6">
+    <div class="form-group two-column-item">
       <%= form.label :phone_number, 'Phone Number', class: "required" %>
       <%= form.text_field :phone_number, required: true, class: "form-control" %>
       <small class="form-text text-muted">Must be in the form ###-###-####</small>
     </div>
-  </div>
 
-  <div class="form-row">
-    <div class="form-group col-md-6">
+    <div class="form-group two-column-item add-padding-bottom">
       <%= form.label(:email_address, "Email Address", class: "required") %>
       <%= form.text_field :email_address, required: true, class: "form-control" %>
     </div>
   </div>
 
-  <%= form.submit "Next", class: "btn btn-primary" %>
+  <%= form.submit "Next", class: "btn btn-primary two-column-left-button" %>
 
 <% end %>

--- a/spec/features/layouts/two_column_layout_spec.rb
+++ b/spec/features/layouts/two_column_layout_spec.rb
@@ -4,25 +4,24 @@ require 'rails_helper'
 
 describe 'Two Column Layout Test', type: :feature, js: true do
   let(:submitter) { FactoryBot.build(:submitter) }
-  let(:container_width) { page.evaluate_script("document.querySelector('.two-column-form').offsetWidth").to_i - 20 }
 
   context 'while submitting a new publication', skip: true do
-    context 'when there is just one author' do
-      it 'adjusts layout from one to two columns based on screen width' do
-        create_submitter(submitter)
-        visit new_other_publication_path
-
-        two_column_layout_present
-        columns_layout_correct_on_all_devices
-      end
-    end
+    # context 'when there is just one author' do
+    #   it 'adjusts layout from one to two columns based on screen width' do
+    #     create_submitter(submitter)
+    #     visit new_other_publication_path
+    #
+    #     two_column_layout_present
+    #     columns_layout_correct_on_all_devices
+    #   end
+    # end
   end
 
-  context 'while editing an existing publication' do
+  context 'while editing an existing publication', skip: true do
     skip true
   end
 
-  context 'while viewing a publication' do
+  context 'while viewing a publication', skip: true do
     skip true
   end
 
@@ -34,9 +33,14 @@ describe 'Two Column Layout Test', type: :feature, js: true do
     end
   end
 
+  def container_width
+    page.evaluate_script("document.querySelector('.two-column-form').offsetWidth").to_i - 20
+  end
+
   def two_column_layout_present
     expect(page).to have_css('.two-column-item', minimum: 1)
   end
+
   def columns_layout_correct_on_all_devices
     columns_layout_correct_on_mobile
     columns_layout_correct_on_tablet
@@ -47,17 +51,17 @@ describe 'Two Column Layout Test', type: :feature, js: true do
     # Mobile view: Expect items to take full container width, indicating a one-column layout
     resize_window_to_mobile
     all('.two-column-item').each do |item|
-      item_width = page.evaluate_script("arguments[0].offsetWidth", item.native).to_i
+      item_width = page.evaluate_script('arguments[0].offsetWidth', item.native).to_i
       expect(item_width).to be_within(10).of(container_width)
     end
   end
 
   def columns_layout_correct_on_tablet
-    # Tablet view: Expect items to take full container width, indicating a one-column layout
+    # Tablet view: Expect items to take half container width, indicating a two-column layout
     resize_window_to_tablet
     all('.two-column-item').each do |item|
-      item_width = page.evaluate_script("arguments[0].offsetWidth", item.native).to_i
-      expect(item_width).to be_within(10).of(container_width)
+      item_width = page.evaluate_script('arguments[0].offsetWidth', item.native).to_i
+      expect(item_width).to be_within(10).of(container_width * 0.45)
     end
   end
 
@@ -65,7 +69,7 @@ describe 'Two Column Layout Test', type: :feature, js: true do
     # Desktop view: Expect items to take half container width, indicating a two-column layout
     resize_window_to_desktop
     all('.two-column-item').each do |item|
-      item_width = page.evaluate_script("arguments[0].offsetWidth", item.native).to_i
+      item_width = page.evaluate_script('arguments[0].offsetWidth', item.native).to_i
       expect(item_width).to be_within(10).of(container_width * 0.45)
     end
   end

--- a/spec/features/layouts/two_column_layout_spec.rb
+++ b/spec/features/layouts/two_column_layout_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Two Column Layout Test', type: :feature, js: true do
+  let(:submitter) { FactoryBot.build(:submitter) }
+  let(:container_width) { page.evaluate_script("document.querySelector('.two-column-form').offsetWidth").to_i - 20 }
+
+  context 'while submitting a new publication', skip: true do
+    context 'when there is just one author' do
+      it 'adjusts layout from one to two columns based on screen width' do
+        create_submitter(submitter)
+        visit new_other_publication_path
+
+        two_column_layout_present
+        columns_layout_correct_on_all_devices
+      end
+    end
+  end
+
+  context 'while editing an existing publication' do
+    skip true
+  end
+
+  context 'while viewing a publication' do
+    skip true
+  end
+
+  context 'while entering in information as a new submitter' do
+    it 'adjusts layout from one to two columns based on screen width' do
+      visit root_path
+      two_column_layout_present
+      columns_layout_correct_on_all_devices
+    end
+  end
+
+  def two_column_layout_present
+    expect(page).to have_css('.two-column-item', minimum: 1)
+  end
+  def columns_layout_correct_on_all_devices
+    columns_layout_correct_on_mobile
+    columns_layout_correct_on_tablet
+    columns_layout_correct_on_desktop
+  end
+
+  def columns_layout_correct_on_mobile
+    # Mobile view: Expect items to take full container width, indicating a one-column layout
+    resize_window_to_mobile
+    all('.two-column-item').each do |item|
+      item_width = page.evaluate_script("arguments[0].offsetWidth", item.native).to_i
+      expect(item_width).to be_within(10).of(container_width)
+    end
+  end
+
+  def columns_layout_correct_on_tablet
+    # Tablet view: Expect items to take full container width, indicating a one-column layout
+    resize_window_to_tablet
+    all('.two-column-item').each do |item|
+      item_width = page.evaluate_script("arguments[0].offsetWidth", item.native).to_i
+      expect(item_width).to be_within(10).of(container_width)
+    end
+  end
+
+  def columns_layout_correct_on_desktop
+    # Desktop view: Expect items to take half container width, indicating a two-column layout
+    resize_window_to_desktop
+    all('.two-column-item').each do |item|
+      item_width = page.evaluate_script("arguments[0].offsetWidth", item.native).to_i
+      expect(item_width).to be_within(10).of(container_width * 0.45)
+    end
+  end
+
+  def resize_window_to_mobile
+    page.driver.browser.manage.window.resize_to(360, 640) # Mobile dimensions
+  end
+
+  def resize_window_to_tablet
+    page.driver.browser.manage.window.resize_to(768, 1024) # Tablet dimensions
+  end
+
+  def resize_window_to_desktop
+    page.driver.browser.manage.window.resize_to(1024, 768) # Desktop dimensions
+  end
+end

--- a/spec/features/layouts/two_column_layout_spec.rb
+++ b/spec/features/layouts/two_column_layout_spec.rb
@@ -5,26 +5,6 @@ require 'rails_helper'
 describe 'Two Column Layout Test', type: :feature, js: true do
   let(:submitter) { FactoryBot.build(:submitter) }
 
-  context 'while submitting a new publication', skip: true do
-    # context 'when there is just one author' do
-    #   it 'adjusts layout from one to two columns based on screen width' do
-    #     create_submitter(submitter)
-    #     visit new_other_publication_path
-    #
-    #     two_column_layout_present
-    #     columns_layout_correct_on_all_devices
-    #   end
-    # end
-  end
-
-  context 'while editing an existing publication', skip: true do
-    skip true
-  end
-
-  context 'while viewing a publication', skip: true do
-    skip true
-  end
-
   context 'while entering in information as a new submitter' do
     it 'adjusts layout from one to two columns based on screen width' do
       visit root_path


### PR DESCRIPTION
Fixes #247 

This PR makes the login page in desktop and tablet views have the submitter form in a 2-column format.  Mobile views have a single-column format.

It creates the two-column format by creating a few new SCSS class names: "two-column-form", "two-column-item", "add-padding-bottom" and "two-column-left-button".  These are designed to be reusable for making the "new" and "edit" publication pages also into a two-column format.

Tests ensure that the submitter creation page displays a 2-column format correctly since it used to have this property and was switched unintentionally to a single-column layout sometime in the last few years.  The tests are designed to be reusable to test the layouts of the publication pages as well.

It sets box-sizing to border-box for the entire app to assist with creating a more uniform layout.

It also removes the underline from the "LIBRARIES" link on the header to conform to UC styling guidelines.

