### PR TITLE
300 - Add autocomplete: 'off' to addAuthor form

### DIFF
--- a/app/assets/javascripts/add_remove_authors.js
+++ b/app/assets/javascripts/add_remove_authors.js
@@ -24,6 +24,10 @@ document.addEventListener("turbolinks:load", function() {
     }
 });
 
+// We have both authors and artists.  This function looks at the text in the
+// "Add Author" button to determine if we are dealing with artist or an author.
+// The "Add Author" button has its text determined by publications_helper's
+// "author_or_artist_label" method.
 function getRoleFromButton() {
     const button = document.getElementById('add_author_btn');
     if (!button) return null; // Return null if the button doesn't exist
@@ -87,6 +91,7 @@ function createInput(type, name) {
         name: `${type}[${name}][]`,
         required: "required",
         class: "form-control form-group",
+        autocomplete: "off",
         "data-type": type
     });
 

--- a/app/views/partials/_author.html.erb
+++ b/app/views/partials/_author.html.erb
@@ -9,11 +9,11 @@
     <div class="form-row" data-type="<%= name %>" data-index=<%= index %> id="author_<%= index %>">
       <div class="col-md-5">
         <%= label_tag("author_first_name_#{index}", "#{author_or_artist_label} First Name", class: "required") %>
-        <%= text_field_tag "#{name}[author_first_name][]", first_name, "data-publication-type": name, id: "author_first_name_#{index}", required: true, class: "form-control form-group" %>
+        <%= text_field_tag "#{name}[author_first_name][]", first_name, "data-publication-type": name, id: "author_first_name_#{index}", autocomplete: 'off', required: true, class: "form-control form-group" %>
       </div>
       <div class="col-md-5">
         <%= label_tag "author_last_name_#{index}", "#{author_or_artist_label} Last Name", class: "required" %>
-        <%= text_field_tag "#{name}[author_last_name][]", last_name, "data-publication-type": name, id: "author_last_name_#{index}", required: true, class: "form-control form-group" %>
+        <%= text_field_tag "#{name}[author_last_name][]", last_name, "data-publication-type": name, id: "author_last_name_#{index}", autocomplete: 'off', required: true, class: "form-control form-group" %>
       </div>
       <% if index > 0 %>
         <div class="col-md-2">


### PR DESCRIPTION
Fixes #300 

We had a minor security issue where if someone hit the back-button in their browser, the author/artist input fields for creating a new work would remain pre-filled with the information that had been previously entered.

This PR adds the tag `autocomplete: 'off'` to the input fields so that when a user uses the browser back-button to return to the new publication page, the fields are not pre-filled.

**Acceptance criteria:**
- User must still be able to fill in the fields and have them save appropriately.
- Fields must still auto-populate when attempting to edit a publication.
- Changes made while editing must persist.
- If a user creates a publication and then uses the browser back-arrow to return to the new publication page, the author fields must not be filled out.  There should only be one author's name field set (first and last name)
- if the user hits "Add Author" after using the back button, the new fields should not be pre-filled with anything.

