### PR TITLE
242 - Sort departments on citations page

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -68,7 +68,10 @@ class AdminController < ApplicationController
         publication.respond_to?(:college_ids) && publication.college_ids.include?(college.id)
       end
       grouped_by_department = publications_in_college.group_by(&:uc_department)
-      @college_array << [college.id, grouped_by_department]
+
+      sorted_departments = grouped_by_department.sort_by { |department, _publications| department }.to_h
+
+      @college_array << [college.id, sorted_departments]
     end
   end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -67,9 +67,15 @@ class AdminController < ApplicationController
       publications_in_college = all_publications.select do |publication|
         publication.respond_to?(:college_ids) && publication.college_ids.include?(college.id)
       end
+
       grouped_by_department = publications_in_college.group_by(&:uc_department)
 
-      sorted_departments = grouped_by_department.sort_by { |department, _publications| department }.to_h
+      sorted_departments = grouped_by_department.transform_values do |publications|
+        publications.sort_by do |publication|
+          full_names = publication.author_last_name.zip(publication.author_first_name).map { |last, first| "#{last.downcase}, #{first.downcase}" }
+          [full_names, publication.work_title.downcase]
+        end
+      end.sort.to_h
 
       @college_array << [college.id, sorted_departments]
     end

--- a/spec/controllers/admin_controller/admin_controller_citations_spec.rb
+++ b/spec/controllers/admin_controller/admin_controller_citations_spec.rb
@@ -21,59 +21,59 @@ RSpec.describe AdminController, type: :controller do
         get :citations
 
         department_order = assigns(:college_array).find { |element| element[0] == 1 }[1].keys
-        expect(department_order).to eq(['Chemistry', 'Mathematics', 'Physics'])
+        expect(department_order).to eq(%w[Chemistry Mathematics Physics])
       end
     end
 
     context 'when publications are present in a department' do
-    context 'with multiple authors where the first author is the same' do
-      before do
-        session[:admin] = true
-        mock_college = double('College', id: 1)
-        allow(College).to receive(:find_each).and_yield(mock_college)
+      context 'with multiple authors where the first author is the same' do
+        before do
+          session[:admin] = true
+          mock_college = double('College', id: 1)
+          allow(College).to receive(:find_each).and_yield(mock_college)
 
-        # Publications with the same first author, different second authors
-        mock_publication1 = double('Publication',
-                                   college_ids: [1], uc_department: 'Literature',
-                                   author_last_name: ['Smith', 'Anderson'], author_first_name: ['John', 'Michael'], work_title: 'Book One')
-        mock_publication2 = double('Publication',
-                                   college_ids: [1], uc_department: 'Literature',
-                                   author_last_name: ['Smith', 'Bell'], author_first_name: ['John', 'Peter'], work_title: 'Book Two')
+          # Publications with the same first author, different second authors
+          mock_publication1 = double('Publication',
+                                     college_ids: [1], uc_department: 'Literature',
+                                     author_last_name: %w[Smith Anderson], author_first_name: %w[John Michael], work_title: 'Book One')
+          mock_publication2 = double('Publication',
+                                     college_ids: [1], uc_department: 'Literature',
+                                     author_last_name: %w[Smith Bell], author_first_name: %w[John Peter], work_title: 'Book Two')
 
-        allow(controller).to receive(:fetch_all_records).and_return([mock_publication1, mock_publication2])
+          allow(controller).to receive(:fetch_all_records).and_return([mock_publication1, mock_publication2])
+        end
+
+        it 'correctly sorts publications within departments by all authors' do
+          get :citations
+
+          sorted_publications_literature = assigns(:college_array).find { |element| element[0] == 1 }[1]['Literature']
+          expect(sorted_publications_literature.map(&:work_title)).to eq(['Book One', 'Book Two'])
+        end
       end
+      context 'with a single author having multiple publications' do
+        before do
+          session[:admin] = true
+          mock_college = double('College', id: 1)
+          allow(College).to receive(:find_each).and_yield(mock_college)
 
-      it 'correctly sorts publications within departments by all authors' do
-        get :citations
+          # Multiple publications by the same author
+          mock_publication1 = double('Publication',
+                                     college_ids: [1], uc_department: 'Science',
+                                     author_last_name: ['Curie'], author_first_name: ['Marie'], work_title: 'Research Findings')
+          mock_publication2 = double('Publication',
+                                     college_ids: [1], uc_department: 'Science',
+                                     author_last_name: ['Curie'], author_first_name: ['Marie'], work_title: 'Early Experiments')
 
-        sorted_publications_literature = assigns(:college_array).find { |element| element[0] == 1 }[1]['Literature']
-        expect(sorted_publications_literature.map(&:work_title)).to eq(['Book One', 'Book Two'])
+          allow(controller).to receive(:fetch_all_records).and_return([mock_publication1, mock_publication2])
+        end
+
+        it 'sorts publications by the same author within departments by work title' do
+          get :citations
+
+          sorted_publications_science = assigns(:college_array).find { |element| element[0] == 1 }[1]['Science']
+          expect(sorted_publications_science.map(&:work_title)).to eq(['Early Experiments', 'Research Findings'])
+        end
       end
-    end
-    context 'with a single author having multiple publications' do
-      before do
-        session[:admin] = true
-        mock_college = double('College', id: 1)
-        allow(College).to receive(:find_each).and_yield(mock_college)
-
-        # Multiple publications by the same author
-        mock_publication1 = double('Publication',
-                                   college_ids: [1], uc_department: 'Science',
-                                   author_last_name: ['Curie'], author_first_name: ['Marie'], work_title: 'Research Findings')
-        mock_publication2 = double('Publication',
-                                   college_ids: [1], uc_department: 'Science',
-                                   author_last_name: ['Curie'], author_first_name: ['Marie'], work_title: 'Early Experiments')
-
-        allow(controller).to receive(:fetch_all_records).and_return([mock_publication1, mock_publication2])
-      end
-
-      it 'sorts publications by the same author within departments by work title' do
-        get :citations
-
-        sorted_publications_science = assigns(:college_array).find { |element| element[0] == 1 }[1]['Science']
-        expect(sorted_publications_science.map(&:work_title)).to eq(['Early Experiments', 'Research Findings'])
-      end
-    end
     end
 
     context 'when logged in as a submitter' do

--- a/spec/controllers/admin_controller/admin_controller_citations_spec.rb
+++ b/spec/controllers/admin_controller/admin_controller_citations_spec.rb
@@ -4,21 +4,76 @@ require 'rails_helper'
 
 RSpec.describe AdminController, type: :controller do
   describe 'GET #citations' do
-    context 'when admin is logged in' do
+    context 'when departments are present in a college' do
       before do
         session[:admin] = true
-        mock_college1 = double('College', id: 1)
-        mock_college2 = double('College', id: 2)
-        allow(College).to receive(:find_each).and_yield(mock_college1).and_yield(mock_college2)
-        allow(controller).to receive(:fetch_all_records).and_return(mocked_records)
+        mock_college = double('College', id: 1)
+        allow(College).to receive(:find_each).and_yield(mock_college)
+
+        mock_publication1 = double('Publication', college_ids: [1], uc_department: 'Physics', author_last_name: ['Newton'], author_first_name: ['Isaac'], work_title: 'Principia Mathematica')
+        mock_publication2 = double('Publication', college_ids: [1], uc_department: 'Mathematics', author_last_name: ['Euler'], author_first_name: ['Leonhard'], work_title: 'Introductio in analysin infinitorum')
+        mock_publication3 = double('Publication', college_ids: [1], uc_department: 'Chemistry', author_last_name: ['Curie'], author_first_name: ['Marie'], work_title: 'Research on Radioactive Substances')
+
+        allow(controller).to receive(:fetch_all_records).and_return([mock_publication1, mock_publication2, mock_publication3])
       end
 
-      let(:mocked_records) { [double('Artwork', college_ids: [1], uc_department: 'Art'), double('Book', college_ids: [2], uc_department: 'Literature')] }
-
-      it 'populates @college_array with grouped records' do
+      it 'correctly sorts departments within the college' do
         get :citations
-        expect(assigns(:college_array)).to eq([[1, { 'Art' => [mocked_records.first] }], [2, { 'Literature' => [mocked_records.last] }]])
+
+        department_order = assigns(:college_array).find { |element| element[0] == 1 }[1].keys
+        expect(department_order).to eq(['Chemistry', 'Mathematics', 'Physics'])
       end
+    end
+
+    context 'when publications are present in a department' do
+    context 'with multiple authors where the first author is the same' do
+      before do
+        session[:admin] = true
+        mock_college = double('College', id: 1)
+        allow(College).to receive(:find_each).and_yield(mock_college)
+
+        # Publications with the same first author, different second authors
+        mock_publication1 = double('Publication',
+                                   college_ids: [1], uc_department: 'Literature',
+                                   author_last_name: ['Smith', 'Anderson'], author_first_name: ['John', 'Michael'], work_title: 'Book One')
+        mock_publication2 = double('Publication',
+                                   college_ids: [1], uc_department: 'Literature',
+                                   author_last_name: ['Smith', 'Bell'], author_first_name: ['John', 'Peter'], work_title: 'Book Two')
+
+        allow(controller).to receive(:fetch_all_records).and_return([mock_publication1, mock_publication2])
+      end
+
+      it 'correctly sorts publications within departments by all authors' do
+        get :citations
+
+        sorted_publications_literature = assigns(:college_array).find { |element| element[0] == 1 }[1]['Literature']
+        expect(sorted_publications_literature.map(&:work_title)).to eq(['Book One', 'Book Two'])
+      end
+    end
+    context 'with a single author having multiple publications' do
+      before do
+        session[:admin] = true
+        mock_college = double('College', id: 1)
+        allow(College).to receive(:find_each).and_yield(mock_college)
+
+        # Multiple publications by the same author
+        mock_publication1 = double('Publication',
+                                   college_ids: [1], uc_department: 'Science',
+                                   author_last_name: ['Curie'], author_first_name: ['Marie'], work_title: 'Research Findings')
+        mock_publication2 = double('Publication',
+                                   college_ids: [1], uc_department: 'Science',
+                                   author_last_name: ['Curie'], author_first_name: ['Marie'], work_title: 'Early Experiments')
+
+        allow(controller).to receive(:fetch_all_records).and_return([mock_publication1, mock_publication2])
+      end
+
+      it 'sorts publications by the same author within departments by work title' do
+        get :citations
+
+        sorted_publications_science = assigns(:college_array).find { |element| element[0] == 1 }[1]['Science']
+        expect(sorted_publications_science.map(&:work_title)).to eq(['Early Experiments', 'Research Findings'])
+      end
+    end
     end
 
     context 'when logged in as a submitter' do


### PR DESCRIPTION
Fixes #242 

This PR sorts the results on the admin Citations page.  Previously, the works were only sorted into departments.  This PR sorts the departments themselves within a college, and then sorts the works by author and then by work_title if the authors are the same.  

This should improve the user experience for the admins as they attempt to prepare their lists, enabling them to more easily spot duplications or errors.