### PR TITLE
397 - Update Capistrano locked version

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.17.1'
+lock '~> 3.18.1'
 
 set :application, 'AAEC'
 set :repo_url, 'https://github.com/uclibs/aaec.git'


### PR DESCRIPTION
Fixes #397 

Updated Capistrano version to 3.18.1 in Gemfile but didn't catch that it was also locked in deploy.rb.  This will test-deploy to libappstest.