### PR TITLE
LIBAAEC-28 Add pinned version of Rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'bigdecimal' # Provides arbitrary-precision decimal floating-point arithmeti
 gem 'csv' # Ruby's standard CSV library, being removed from Ruby in version 3.4.0
 gem 'drb' # Distributed Ruby, being removed from Ruby in version 3.4.0
 gem 'mutex_m' # Required for activestorage, being removed from Ruby in version 3.4.0
-gem 'rexml', '>= 3.3.3' # XML parsing library, addressing bundle audit issues
+gem 'rexml', '>= 3.3.6' # XML parsing library, addressing bundle audit issues
 
 # Core Rails gems
 gem 'rails', '~> 6.1.7.7' # The Rails framework

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'bigdecimal' # Provides arbitrary-precision decimal floating-point arithmeti
 gem 'csv' # Ruby's standard CSV library, being removed from Ruby in version 3.4.0
 gem 'drb' # Distributed Ruby, being removed from Ruby in version 3.4.0
 gem 'mutex_m' # Required for activestorage, being removed from Ruby in version 3.4.0
+gem 'rexml', '>= 3.3.3' # XML parsing library, addressing bundle audit issues
 
 # Core Rails gems
 gem 'rails', '~> 6.1.7.7' # The Rails framework

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,7 @@ DEPENDENCIES
   rails (~> 6.1.7.7)
   rails-controller-testing
   rb-readline
+  rexml (>= 3.3.3)
   rspec-rails
   rspec_junit_formatter
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
       ffi (~> 1.0)
     rb-readline (0.5.5)
     regexp_parser (2.9.2)
-    rexml (3.3.5)
+    rexml (3.3.6)
       strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
@@ -433,7 +433,7 @@ DEPENDENCIES
   rails (~> 6.1.7.7)
   rails-controller-testing
   rb-readline
-  rexml (>= 3.3.3)
+  rexml (>= 3.3.6)
   rspec-rails
   rspec_junit_formatter
   rubocop


### PR DESCRIPTION
[Jira issue referenced](https://ucdts.atlassian.net/browse/LIBAAEC-28)

We are having dependabot PR's failing because of an old version of `rexml` being used in the Gemfile.lock.  `rexml` is not currently a direct dependency to AAEC.  This PR adds `rexml` as a dependency and pins the version to the required >=3.3.6.